### PR TITLE
Rudy/batch metrics

### DIFF
--- a/examples/example.php
+++ b/examples/example.php
@@ -8,4 +8,11 @@ DataDogStatsD::increment('web.page_views');
 DataDogStatsD::histogram('web.render_time', 15);
 DataDogStatsD::set('web.uniques', 3 /* a unique user id */);
 
+
+//All the following metrics will be sent in a single UDP packet to the statsd server
+BatchedDatadogStatsD::increment('web.page_views')
+BatchedDatadogStatsD::histogram('web.render_time', 15);
+BatchedDatadogStatsD::set('web.uniques', 3 /* a unique user id */);
+BatchedDatadogStatsD::flush_buffer(); // Necessary
+
 ?>


### PR DESCRIPTION
Allow to send multiple metrics in a single udp packet.
To send them in batch, use `BatchedDatadogstatsD` instead of `DatadogStatsd` and add a call to `BatchedDatadogstD::flush_buffer()` at the end.

To avoid to create too large UDP packets, if more than 50 metrics are reported, it will automatically be flushed.

Similar to https://github.com/DataDog/dogstatsd-ruby/pull/7 and https://github.com/DataDog/dogstatsd-python/pull/19
