### PR TITLE
Replace dependency on PECL http version 1.7.6 extension with curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ DataDogStatsD::timing('your.data.point', microtime(true) - $start_time, 1, array
 
 ### Submitting events
 
-Requires PHP >= 5.3.0 with the [PECL http version 1.7.6](http://www.php.net/manual/en/http.install.php) extension
+Requires PHP >= 5.3.0 with the curl extension
 
 To submit events, you'll need to first configure the library with your
 Datadog credentials, since the event function submits directly to Datadog

--- a/libraries/datadogstatsd.php
+++ b/libraries/datadogstatsd.php
@@ -231,16 +231,17 @@ class Datadogstatsd {
              . '?api_key='            . static::$__apiKey
              . '&application_key='    . static::$__applicationKey;
 
-        // Set up the http request. Need the PECL pecl_http extension
-        $r = new HttpRequest($url, HttpRequest::METH_POST);
-        $r->addHeaders(array('Content-Type' => 'application/json'));
-        $r->setBody($body);
-
-        // Send, suppressing and logging any http errors
-        try {
-            $r->send();
-        } catch (HttpException $ex) {
-            error_log($ex);
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
+        curl_setopt($ch, CURLOPT_HEADER, 1);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_POST, 1);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+        $response = curl_exec($ch);
+        $errorMessage = curl_error($ch);
+        curl_close($ch);
+        if (!empty($errorMessage)) {
+            error_log($errorMessage);
         }
     }
 

--- a/libraries/datadogstatsd.php
+++ b/libraries/datadogstatsd.php
@@ -205,7 +205,7 @@ class Datadogstatsd {
     /**
      * Send an event to the Datadog HTTP api. Potentially slow, so avoid
      * making many call in a row if you don't want to stall your app.
-     * Requires PHP >= 5.3.0 and the PECL extension pecl_http
+     * Requires PHP >= 5.3.0 and the curl extension
      *
      * @param string $title Title of the event
      * @param array $vals Optional values of the event. See


### PR DESCRIPTION
Replace dependency on PECL http version 1.7.6 extension with the more commonly installed curl extension. Functionality is unchanged.