### PR TITLE
Remove requirement for any extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ DataDogStatsD::timing('your.data.point', microtime(true) - $start_time, 1, array
 
 ### Submitting events
 
-Requires PHP >= 5.3.0 with the [PECL http version 1.7.6](http://www.php.net/manual/en/http.install.php) extension
+~~Requires PHP >= 5.3.0 with the [PECL http version 1.7.6](http://www.php.net/manual/en/http.install.php) extension~~
+Requires PHP >= 5.3.0
 
 To submit events, you'll need to first configure the library with your
 Datadog credentials, since the event function submits directly to Datadog
@@ -80,3 +81,5 @@ directly to Datadog over HTTP. We'd like to improve this in the near future.
 ## Author
 
 Alex Corley - anthroprose@gmail.com
+
+Matt Williams - m@technovangelist.com removed dependency on PECL extension

--- a/libraries/datadogstatsd.php
+++ b/libraries/datadogstatsd.php
@@ -8,6 +8,8 @@
  * I did make it the most effecient UDP process possible, and add tagging.
  * 
  * @author Alex Corley <anthroprose@gmail.com>
+ *
+ * Updated by Matt Williams <m@technovangelist.com> to remove dependency on any PECL extensions
  **/
  
 class Datadogstatsd {
@@ -207,6 +209,8 @@ class Datadogstatsd {
      * making many call in a row if you don't want to stall your app.
      * Requires PHP >= 5.3.0 and the PECL extension pecl_http
      *
+     * Updated by Matt Williams to not require any PECL extensions
+     *
      * @param string $title Title of the event
      * @param array $vals Optional values of the event. See
      *   http://api.datadoghq.com/events for the valid keys
@@ -225,21 +229,28 @@ class Datadogstatsd {
         }
 
         $body = json_encode($vals); // Added in PHP 5.3.0
-
+		$opts = array(
+			'http'=> array(
+				'method' => 'POST',
+				'header' => 'Content-Type: application/json',
+				'content' => $body
+			)
+		);
+	    $context = stream_context_create( $opts );
         // Get the url to POST to
         $url = static::$__datadogHost . static::$__eventUrl
              . '?api_key='            . static::$__apiKey
              . '&application_key='    . static::$__applicationKey;
 
         // Set up the http request. Need the PECL pecl_http extension
-        $r = new HttpRequest($url, HttpRequest::METH_POST);
-        $r->addHeaders(array('Content-Type' => 'application/json'));
-        $r->setBody($body);
-
+//        $r = new HttpRequest($url, HttpRequest::METH_POST);
+//        $r->addHeaders(array('Content-Type' => 'application/json'));
+//        $r->setBody($body);
+//
         // Send, suppressing and logging any http errors
         try {
-            $r->send();
-        } catch (HttpException $ex) {
+	        file_get_contents( $url, 0, $context );
+        } catch (Exception $ex) {
             error_log($ex);
         }
     }


### PR DESCRIPTION
While adding PECL extensions or support for curl is not technically difficult, it can be restricted by the host. Also requiring an extension for a single monitoring method seems overkill. Streams are a php native way to achieve the same thing. 

This was bothering me for a few days so I made the quick and easy fix...

All that was required was to create a context: 
```
$opts = array(
   'http'=> array(
      'method' => 'POST',
      'header' => 'Content-Type: application/json',
      'content' => $body
   )
);
$context = stream_context_create( $opts );
```

then get the contents: 
```
file_get_contents( $url, 0, $context );
```