### PR TITLE
[autoload] Added classmap autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,8 @@
     	"irc": "irc://irc.freenode.net/datadog",
     	"issues": "https://github.com/DataDog/php-datadogstatsd/issues",
     	"source": "https://github.com/DataDog/php-datadogstatsd"
+    },
+    "autoload": {
+        "classmap": ["libraries/"]
     }
 }


### PR DESCRIPTION
Now the php-datadogstatsd library can easily be autoloaded using
Composer. Thanks a lot to pwillcode for his contribution (https://github.com/DataDog/php-datadogstatsd/pull/14) !