### PR TITLE
Get free from all PECL ext. & other dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ DataDogStatsD::timing('your.data.point', microtime(true) - $start_time, 1, array
 
 ### Submitting events
 
-Requires PHP >= 5.3.0 with the [PECL http version 1.7.6](http://www.php.net/manual/en/http.install.php) extension
+Requires PHP >= 5.3.0
 
 To submit events, you'll need to first configure the library with your
 Datadog credentials, since the event function submits directly to Datadog
@@ -91,3 +91,5 @@ directly to Datadog over HTTP. We'd like to improve this in the near future.
 ## Author
 
 Alex Corley - anthroprose@gmail.com
+
+Matt Williams - m@technovangelist.com removed dependency on PECL extension

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Add the following to your `composer.json`:
 Note: The first version shipped in composer is 0.0.3
 
 
-### Or manually 
+### Or manually
 
 Clone repository at [github.com/DataDog/php-datadogstatsd](https://github.com/DataDog/php-datadogstatsd)
 
 Setup: `require './libraries/datadogstatsd.php';`
- 
+
 ## Usage
 
 ### Increment
@@ -87,9 +87,3 @@ For more documentation on the optional values of events, see [http://docs.datado
 Note that while sending metrics with this library is fast since it's sending
 locally over UDP, sending events will be slow because it's sending data
 directly to Datadog over HTTP. We'd like to improve this in the near future.
-
-## Author
-
-Alex Corley - anthroprose@gmail.com
-
-Matt Williams - m@technovangelist.com removed dependency on PECL extension

--- a/libraries/datadogstatsd.php
+++ b/libraries/datadogstatsd.php
@@ -6,10 +6,6 @@
  * Most of this code was stolen from: https://gist.github.com/1065177/5f7debc212724111f9f500733c626416f9f54ee6
  *
  * I did make it the most effecient UDP process possible, and add tagging.
- *
- * @author Alex Corley <anthroprose@gmail.com>
- *
- * Updated by Matt Williams <m@technovangelist.com> to remove dependency on any PECL extensions
  **/
 
 class Datadogstatsd {
@@ -210,9 +206,7 @@ class Datadogstatsd {
     /**
      * Send an event to the Datadog HTTP api. Potentially slow, so avoid
      * making many call in a row if you don't want to stall your app.
-     * Requires PHP >= 5.3.0 and the PECL extension pecl_http
-     *
-     * Updated by Matt Williams to not require any PECL extensions
+     * Requires PHP >= 5.3.0
      *
      * @param string $title Title of the event
      * @param array $vals Optional values of the event. See


### PR DESCRIPTION
The library has been updated to no longer requires the curl PECL
extension (not installed by default on many PHP distributions).
The library is now dependency-free (it's using PHP streams instead
of curl).

Note : the README.md has been updated accordingly.