### PR TITLE
Allow configuration of local UDP port

### DIFF
--- a/libraries/datadogstatsd.php
+++ b/libraries/datadogstatsd.php
@@ -11,6 +11,7 @@
 class Datadogstatsd {
 
     static protected $__server = 'localhost';
+    static protected $__serverPort = 8125;
     static private $__datadogHost;
     static private $__eventUrl = '/api/v1/events';
     static private $__apiKey;
@@ -205,7 +206,7 @@ class Datadogstatsd {
         // Non - Blocking UDP I/O - Use IP Addresses!
         $socket = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
         socket_set_nonblock($socket);
-        socket_sendto($socket, $udp_message, strlen($udp_message), 0, static::$__server, 8125);
+        socket_sendto($socket, $udp_message, strlen($udp_message), 0, static::$__server, static::$__serverPort);
         socket_close($socket);
 
     }


### PR DESCRIPTION
Allow configuration of the local UDP for that the `dd-agent` server is listening on. Pretty straight forward change. We've already consumed port 8125 and run on 8126... 

Not much more to say.