### PR TITLE
Maxime/fix udp event

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ Setup: `require './libraries/datadogstatsd.php';`
 
 ## Usage
 
+The 'tags' argument can be a array or a string. Value can be set to `null`.
+
+```php
+# Both call will send the "app:php1" and "beta" tags.
+Datadogstatsd::increment('your.data.point', 1, array('app' => 'php1', 'beta' => null));
+Datadogstatsd::increment('your.data.point', 1, "app:php1,beta");
+```
+
 ### Increment
 
 To increment things:

--- a/libraries/datadogstatsd.php
+++ b/libraries/datadogstatsd.php
@@ -363,7 +363,7 @@ class Datadogstatsd {
         //   http://docs.datadoghq.com/guides/dogstatsd/#events
         $fields = '';
         $fields .= ($title);
-        $fields .= ($text) ? '|' . $text : '|';
+        $fields .= ($text) ? '|' . str_replace("\n", "\\n", $text) : '|';
         $fields .= (isset($vals['date_happened'])) ? '|d:' . ((string) $vals['date_happened']) : '';
         $fields .= (isset($vals['hostname'])) ? '|h:' . ((string) $vals['hostname']) : '';
         $fields .= (isset($vals['priority'])) ? '|p:' . ((string) $vals['priority']) : '';

--- a/libraries/datadogstatsd.php
+++ b/libraries/datadogstatsd.php
@@ -366,7 +366,9 @@ class Datadogstatsd {
         $fields .= ($text) ? '|' . str_replace("\n", "\\n", $text) : '|';
         $fields .= (isset($vals['date_happened'])) ? '|d:' . ((string) $vals['date_happened']) : '';
         $fields .= (isset($vals['hostname'])) ? '|h:' . ((string) $vals['hostname']) : '';
+        $fields .= (isset($vals['aggregation_key'])) ? '|k:' . ((string) $vals['aggregation_key']) : '';
         $fields .= (isset($vals['priority'])) ? '|p:' . ((string) $vals['priority']) : '';
+        $fields .= (isset($vals['source_type_name'])) ? '|s:' . ((string) $vals['source_type_name']) : '';
         $fields .= (isset($vals['alert_type'])) ? '|t:' . ((string) $vals['alert_type']) : '';
         $fields .= (isset($vals['tags'])) ? static::serialize_tags($vals['tags']) : '';
 


### PR DESCRIPTION
# UDP event

- Add support for 'aggregation_key' and 'source_type_name' in UDP events (Pointed at in #39)
- Support line break in text

# Tag behavior

Align tags behaviour across all functions

Tags were behaving differently between metrics, TCP events and UDP events over UDP. We now handle associative array and string everywhere. Tags also follow dogstatsd documentation by supporting tags with no value.
