### PR TITLE
Support global tags, refactor internals of tag handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ DogStatsd constructor, takes a configuration array. The configuration can take a
 - `host`: the host of your DogStatsd server, default to `localhost`
 - `port`: the port of your DogStatsd server. default to `8125`
 - `socket_path`: the path to the DogStatsd UNIX socket (overrides `host` and `port`, only supported with `datadog-agent` >= 6). default to `null`
+- `global_tags`: tags to apply to all metrics sent
 
 When sending `events` over TCP the following options can be set (see [Events section](#submitting-events)):
 

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -80,7 +80,7 @@ class DogStatsd
         $this->apiKey = isset($config['api_key']) ? $config['api_key'] : null;
         $this->appKey = isset($config['app_key']) ? $config['app_key'] : null;
 
-        $this->globalTags = isset($config['global_tags']) ? $config['global_tags'] : [];
+        $this->globalTags = isset($config['global_tags']) ? $config['global_tags'] : array();
 
         if ($this->apiKey !== null) {
             $this->submitEventsOver = 'TCP';
@@ -236,7 +236,7 @@ class DogStatsd
         if (!$all_tags) {
             return '';
         }
-        $tag_strings = [];
+        $tag_strings = array();
         foreach ($all_tags as $tag => $value) {
             if ($value === null) {
                 $tag_strings[] = $tag;

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -233,7 +233,7 @@ class DogStatsd
             $this->normalize_tags($this->globalTags)
         );
 
-        if (!$all_tags) {
+        if (count($all_tags) === 0) {
             return '';
         }
         $tag_strings = array();

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -229,8 +229,8 @@ class DogStatsd
     private function serialize_tags($tags)
     {
         $all_tags = array_merge(
-            $this->normalize_tags($tags),
-            $this->normalize_tags($this->globalTags)
+            $this->normalize_tags($this->globalTags),
+            $this->normalize_tags($tags)
         );
 
         if (count($all_tags) === 0) {
@@ -255,6 +255,9 @@ class DogStatsd
      */
     private function normalize_tags($tags)
     {
+        if ($tags === null) {
+            return array();
+        }
         if (is_array($tags)) {
             $data = array();
             foreach ($tags as $tag_key => $tag_val) {
@@ -272,7 +275,7 @@ class DogStatsd
                 if (false === strpos($tag_string, ':')) {
                     $data[$tag_string] = null;
                 } else {
-                    list($key, $value) = explode(':', $tag_string, 1);
+                    list($key, $value) = explode(':', $tag_string, 2);
                     $data[$key] = $value;
                 }
             }


### PR DESCRIPTION
This takes the [global_tags](https://github.com/mrbar42/node-dogstatsd/blob/master/lib/statsd.js#L22) concept from the nodejs datadog library and adds equivalent support to the PHP library.

It also refactors the internals of tag handling a bit, since there are currently three (!) different formats that constitute a valid tag. The output is unchanged, but it will now de-duplicate any repeated tags. If a tag has a different value in a direct metric vs the global one, it will apply the tag provided in the metric, replacing the global one.