### PR TITLE
Fix: Use declared private fields

### DIFF
--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -65,8 +65,8 @@ class DogStatsd
         $this->host = isset($config['host']) ? $config['host'] : 'localhost';
         $this->port = isset($config['port']) ? $config['port'] : 8125;
         $this->datadogHost = isset($config['datadog_host']) ? $config['datadog_host'] : 'https://app.datadoghq.com';
-        $this->apiCurlSslVerifyHost = isset($config['curl_ssl_verify_host']) ? $config['curl_ssl_verify_host'] : 2;
-        $this->apiCurlSslVerifyPeer = isset($config['curl_ssl_verify_peer']) ? $config['curl_ssl_verify_peer'] : 1;
+        $this->curlVerifySslHost = isset($config['curl_ssl_verify_host']) ? $config['curl_ssl_verify_host'] : 2;
+        $this->curlVerifySslPeer = isset($config['curl_ssl_verify_peer']) ? $config['curl_ssl_verify_peer'] : 1;
 
         $this->apiKey = isset($config['api_key']) ? $config['api_key'] : null;
         $this->appKey = isset($config['app_key']) ? $config['app_key'] : null;


### PR DESCRIPTION
This PR

* [x] uses declared private fields when assigning values in constructor

💁‍♂️ Running

```
$ phpstan analyse --level=1 src
```

yields

```
 2/2 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ---------------------------------------------------------------------------
  Line   src/DogStatsd.php
 ------ ---------------------------------------------------------------------------
  72     Access to an undefined property DataDog\DogStatsd::$apiCurlSslVerifyHost.
  73     Access to an undefined property DataDog\DogStatsd::$apiCurlSslVerifyPeer.
 ------ ---------------------------------------------------------------------------


 [ERROR] Found 2 errors
```

