### PR TITLE
Fix for text truncation for UDP events

### DIFF
--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -418,7 +418,8 @@ class DogStatsd
         //   http://docs.datadoghq.com/guides/dogstatsd/#events
         $fields = '';
         $fields .= ($title);
-        $fields .= ($text) ? '|' . str_replace("\n", "\\n", $text) : '|';
+        $textField = ($text) ? '|' . str_replace("\n", "\\n", $text) : '|';
+        $fields .= $textField;
         $fields .= (isset($vals['date_happened'])) ? '|d:' . ((string) $vals['date_happened']) : '';
         $fields .= (isset($vals['hostname'])) ? '|h:' . ((string) $vals['hostname']) : '';
         $fields .= (isset($vals['aggregation_key'])) ? '|k:' . ((string) $vals['aggregation_key']) : '';
@@ -428,7 +429,7 @@ class DogStatsd
         $fields .= (isset($vals['tags'])) ? $this->serialize_tags($vals['tags']) : '';
 
         $title_length = strlen($title);
-        $text_length = strlen($text);
+        $text_length = strlen($textField)-1;
 
         $this->report('_e{' . $title_length . ',' . $text_length . '}:' . $fields);
 


### PR DESCRIPTION
Escaping of \n was not being counted for the text length. This would lead to truncation of the event text on Datadog where the number of characters lost was equal to the number of escapes.