### PR TITLE
Add unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ php:
   - 7.1
   - 7.2
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 # http://docs.travis-ci.com/user/build-configuration/#Rows-That-are-Allowed-To-Fail
 matrix:
   fast_finish: true
@@ -16,5 +20,9 @@ matrix:
       dist: precise
 
 script:
-  # check syntax all PHP files, redirect stderr to file and return 0 if file is empty
+  # Check syntax all PHP files, redirect stderr to file and return 0 if file is empty
   - find . -name '*.php' -exec php -l {} > /dev/null \; 2> /tmp/lint.err ; test ! -s /tmp/lint.err
+
+  # Execute PHPUnit tests
+  - composer install --prefer-dist
+  - vendor/bin/phpunit --coverage-text

--- a/README.md
+++ b/README.md
@@ -169,3 +169,11 @@ $statsd->event('Now it is fixed.',
 - Add a configurable timeout for event submission via TCP
 - Write unit tests
 - Document service check functionality
+
+## Contributing
+
+### Tests
+
+```bash
+composer test
+```

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,15 @@
             "DataDog\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "DataDog\\": "tests/"
+        }
+    },
     "config": {
         "sort-packages": true
+    },
+    "require-dev": {
+        "phpunit/phpunit": "5.7.27"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,11 @@
         }
     },
     "autoload-dev": {
+        "files": [
+            "tests/curl_and_error_log_function_stubs.php",
+            "tests/mt_rand_function_stubs.php",
+            "tests/socket_function_stubs.php"
+        ],
         "psr-4": {
             "DataDog\\": "tests/"
         }
@@ -42,6 +47,9 @@
         "sort-packages": true
     },
     "require-dev": {
-        "phpunit/phpunit": "5.7.27"
+        "phpunit/phpunit": "4.8.36"
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         colors="true"
+         verbose="true">
+    <testsuite name="unit">
+        <directory suffix="Test.php">tests/UnitTests</directory>
+    </testsuite>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/tests/TestHelpers/CurlSpy.php
+++ b/tests/TestHelpers/CurlSpy.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace DataDog\TestHelpers;
+
+/**
+ * Class CurlSpy
+ *
+ * Useful for recording calls to stubbed global curl functions built into PHP
+ *
+ * @see \DataDog\CurlSpyTestCase
+ * @package DataDog
+ */
+class CurlSpy
+{
+    /**
+     * @var array
+     */
+    public $argsFromCurlInitCalls = array();
+
+    /**
+     * @var array
+     */
+    public $curlInitReturnValues = array();
+
+    /**
+     * @var array
+     */
+    public $argsFromCurlSetoptCalls = array();
+
+    /**
+     * @var array
+     */
+    public $argsFromCurlExecCalls = array();
+
+    /**
+     * @var string
+     */
+    public $responseBody = '';
+
+    /**
+     * @var array
+     */
+    public $argsFromCurlGetinfoCalls = array();
+
+    /**
+     * @var int
+     */
+    public $responseCode;
+
+    /**
+     * @var array
+     */
+    public $argsFromCurlErrnoCalls = array();
+
+    /**
+     * @var int
+     */
+    public $errorNumber;
+
+    /**
+     * @var array
+     */
+    public $argsFromCurlCloseCalls = array();
+
+    /**
+     * @var array
+     */
+    public $argsFromErrorLogCalls = array();
+
+    /**
+     * @param string $url
+     */
+    public function curlInitWasCalledWithArg($url)
+    {
+        $this->argsFromCurlInitCalls[] = $url;
+    }
+
+    /**
+     * @param resource $ch
+     */
+    public function curlInitDidReturn($ch)
+    {
+        $this->curlInitReturnValues[] = $ch;
+    }
+
+    /**
+     * @var array
+     */
+    public $argsFromCurlErrorCalls = array();
+
+    /**
+     * @var string
+     */
+    public $curlError = "";
+
+    /**
+     * @param resource $ch
+     * @param int $option
+     * @param mixed $value
+     */
+    public function curlSetoptWasCalledWithArgs(
+        $ch,
+        $option,
+        $value
+    ) {
+        $this->argsFromCurlSetoptCalls[] = array(
+            $ch,
+            $option,
+            $value,
+        );
+    }
+
+    /**
+     * @param resource $ch
+     */
+    public function curlExecCalledWithArg($ch)
+    {
+        $this->argsFromCurlExecCalls[] = $ch;
+    }
+
+    /**
+     * @param resource $ch
+     */
+    public function curlExecDidReturn($ch)
+    {
+        $this->curlExecReturnValues[] = $ch;
+    }
+
+    /**
+     * @param resource $ch
+     * @param int $opt
+     */
+    public function curlGetinfoCalledWithArgs($ch, $opt)
+    {
+        $this->argsFromCurlGetinfoCalls[] = array($ch, $opt);
+    }
+
+    /**
+     * @param resource $ch
+     */
+    public function curlErrnoCalledWithArg($ch)
+    {
+        $this->argsFromCurlErrnoCalls[] = $ch;
+    }
+
+    /**
+     * @param resource $ch
+     */
+    public function curlCloseCalledWithArg($ch)
+    {
+        $this->argsFromCurlCloseCalls[] = $ch;
+    }
+
+    /**
+     * @param resource $ch
+     */
+    public function curlErrorCalledWithArg($ch)
+    {
+        $this->argsFromCurlErrorCalls[] = $ch;
+    }
+
+    /**
+     * @param string $message
+     */
+    public function errorLogCallsWithArg($message)
+    {
+        $this->argsFromErrorLogCalls[] = $message;
+    }
+}

--- a/tests/TestHelpers/CurlSpyTestCase.php
+++ b/tests/TestHelpers/CurlSpyTestCase.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DataDog\TestHelpers;
+
+use PHPUnit\Framework\TestCase;
+
+$curlSpy = new CurlSpy();
+
+class CurlSpyTestCase extends TestCase
+{
+    /**
+     * Set up a spy object to capture calls to built in curl functions
+     */
+    protected function setUp()
+    {
+        global $curlSpy;
+
+        $curlSpy = new CurlSpy();
+
+        parent::setUp();
+    }
+
+    /**
+     * @return \DataDog\TestHelpers\CurlSpy
+     */
+    protected function getCurlSpy()
+    {
+        global $curlSpy;
+
+        return $curlSpy;
+    }
+}

--- a/tests/TestHelpers/SocketSpy.php
+++ b/tests/TestHelpers/SocketSpy.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace DataDog\TestHelpers;
+
+/**
+ * Class SocketSpy
+ *
+ * Useful for recording calls to stubbed global socket functions built into PHP
+ *
+ * @see \DataDog\SocketSpyTestCase
+ * @package DataDog
+ */
+class SocketSpy
+{
+    /**
+     * @var array
+     */
+    public $argsFromSocketCreateCalls = array();
+
+    /**
+     * @var array
+     */
+    public $socketCreateReturnValues = array();
+
+    /**
+     * @var array
+     */
+    public $argsFromSocketSetNonblockCalls = array();
+
+    /**
+     * @var array
+     */
+    public $argsFromSocketSendtoCalls = array();
+
+    /**
+     * @var array
+     */
+    public $argsFromSocketCloseCalls = array();
+
+    /**
+     * @param int $domain
+     * @param int $type
+     * @param int $protocol
+     */
+    public function socketCreateWasCalledWithArgs($domain, $type, $protocol)
+    {
+        $this->argsFromSocketCreateCalls[] = array(
+            $domain,
+            $type,
+            $protocol
+        );
+    }
+
+    /**
+     * @param resource $socket
+     */
+    public function socketCreateDidReturn($socket)
+    {
+        $this->socketCreateReturnValues[] = $socket;
+    }
+
+    /**
+     * @param resource $socket
+     */
+    public function socketSetNonblockWasCalledWithArg($socket)
+    {
+        $this->argsFromSocketSetNonblockCalls[] = $socket;
+    }
+
+    /**
+     * @param resource $socket
+     * @param string $buf
+     * @param int $len
+     * @param int $flags
+     * @param string $addr
+     * @param int $port
+     */
+    public function socketSendtoWasCalledWithArgs(
+        $socket,
+        $buf,
+        $len,
+        $flags,
+        $addr,
+        $port
+    ) {
+        $this->argsFromSocketSendtoCalls[] = array(
+            $socket,
+            $buf,
+            $len,
+            $flags,
+            $addr,
+            $port
+        );
+    }
+
+    /**
+     * @param resource $socket
+     */
+    public function socketCloseWasCalled($socket)
+    {
+        $this->argsFromSocketCloseCalls[] = $socket;
+    }
+}

--- a/tests/TestHelpers/SocketSpyTestCase.php
+++ b/tests/TestHelpers/SocketSpyTestCase.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace DataDog\TestHelpers;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Making this variable global to this file is necessary for interacting with
+ * the stubbed global functions below.
+ */
+$socketSpy = new SocketSpy();
+
+/**
+ * Class SocketSpyTestCase
+ *
+ * A PHPUnit TestCase useful for spying on calls to global built in socket
+ * functions
+ *
+ * @package DataDog
+ */
+class SocketSpyTestCase extends TestCase
+{
+    /**
+     * Set up a spy object to capture calls to global built in socket functions
+     */
+    protected function setUp()
+    {
+        global $socketSpy;
+
+        $socketSpy = new SocketSpy();
+
+        parent::setUp();
+    }
+
+    /**
+     * @return \DataDog\TestHelpers\SocketSpy
+     */
+    protected function getSocketSpy()
+    {
+        global $socketSpy;
+
+        return $socketSpy;
+    }
+}

--- a/tests/UnitTests/BatchedDogStatsdTest.php
+++ b/tests/UnitTests/BatchedDogStatsdTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace DataDog\UnitTests;
+
+use DataDog\BatchedDogStatsd;
+use DataDog\TestHelpers\SocketSpy;
+use DataDog\TestHelpers\SocketSpyTestCase;
+
+class BatchedDogStatsdTest extends SocketSpyTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        // Flush the buffer to reset state for next test
+        BatchedDogStatsd::$maxBufferLength = 50;
+        $batchedDog = new BatchedDogStatsd(array());
+        $batchedDog->flush_buffer();
+
+        // Reset the SocketSpy state to get clean assertions.
+        // @see \DataDog\SocketSpy
+        global $socketSpy;
+        $socketSpy = new SocketSpy();
+    }
+
+    public function testReportDoesNotSendIfBufferNotFilled()
+    {
+        $batchedDog = new BatchedDogStatsd(array());
+
+        $batchedDog->report('some fake UDP message');
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            0,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should not send UDP message until buffer is filled'
+        );
+    }
+
+    public function testReportSendsOnceBufferIsFilled()
+    {
+        $batchedDog = new BatchedDogStatsd(array());
+
+        $batchedDog::$maxBufferLength = 2;
+
+        $udpMessage = 'some fake UDP message';
+        $expectedUdpMessageOnceSent = $udpMessage . "1\n"
+            . $udpMessage . "2\n"
+            . $udpMessage . "3";
+
+        $batchedDog->report($udpMessage . '1');
+        $batchedDog->report($udpMessage . '2');
+        $batchedDog->report($udpMessage . '3');
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send all buffered UDP messages once buffer is filled'
+        );
+
+        $this->assertSame(
+            $expectedUdpMessageOnceSent,
+            $spy->argsFromSocketSendtoCalls[0][1],
+            'Should concatenate UDP messages with newlines'
+        );
+    }
+}

--- a/tests/UnitTests/DogStatsd/CurlTest.php
+++ b/tests/UnitTests/DogStatsd/CurlTest.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace DataDog\UnitTests\DogStatsd;
+
+use DateTime;
+use Exception;
+use DataDog\DogStatsd;
+use DataDog\TestHelpers\CurlSpyTestCase;
+
+class CurlTest extends CurlSpyTestCase
+{
+    public function testEvent()
+    {
+        $eventTitle = 'Some event title';
+        $eventVals = array(
+            'text'             => "Some event text\nthat spans 2 lines",
+            'date_happened'    => $this->getDeterministicTimestamp(),
+            'hostname'         => 'some.host.com',
+            'aggregation_key'  => '83e2cf',
+            'priority'         => 'normal',
+            'source_type_name' => 'jenkins',
+            'alert_type'       => 'warning',
+            'tags'             => array(
+                0 => 'chicken:nachos',
+            ),
+        );
+
+        $expectedVals = array_merge($eventVals, array(
+            'title' => $eventTitle,
+        ));
+
+        $expectedVals['tags'][0] = '0:' . $eventVals['tags'][0];
+
+        $dog = new DogStatsd($this->getDogStatsdConfigForSendingEventOverCurl());
+
+        $spy = $this->getCurlSpy();
+
+        $spy->errorNumber = null;
+        $spy->responseCode = 200;
+        $spy->responseBody = json_encode(array('status' => 'ok'));
+
+        $eventSendResult = $dog->event($eventTitle, $eventVals);
+
+        $this->assertSame(
+            array(
+                'https://app.datadoghq.com/api/v1/events?api_key=some-api-key&application_key=some-app-key'
+            ),
+            $spy->argsFromCurlInitCalls,
+            'Should initialize curl with expected url'
+        );
+
+        $this->assertSame(
+            7,
+            count($spy->argsFromCurlSetoptCalls),
+            'Should call curl_setopt 7 times'
+        );
+
+        /**
+         * @todo While technically correct, this test asserts on buggy behavior.
+         *       The constructor for \DataDog\DogStatsd references the wrong
+         *       instance property when parsing the config array, so until that
+         *       bug is fixed, CURL_SSL_VERIFYPEER will always be set to null.
+         * @see  https://github.com/DataDog/php-datadogstatsd/pull/65
+         */
+        $this->assertSame(
+            array(
+                $spy->curlInitReturnValues[0],
+                CURLOPT_SSL_VERIFYPEER,
+                null,
+            ),
+            $spy->argsFromCurlSetoptCalls[0],
+            'Should configure curl to verify SSL peer'
+        );
+
+        /**
+         * @todo While technically correct, this test asserts on buggy behavior.
+         *       The constructor for \DataDog\DogStatsd references the wrong
+         *       instance property when parsing the config array, so until that
+         *       bug is fixed, CURL_SSL_VERIFYHOST will always be set to null.
+         * @see  https://github.com/DataDog/php-datadogstatsd/pull/65
+         */
+        $this->assertSame(
+            array(
+                $spy->curlInitReturnValues[0],
+                CURLOPT_SSL_VERIFYHOST,
+                null,
+            ),
+            $spy->argsFromCurlSetoptCalls[1],
+            'Should configure curl to verify SSL host'
+        );
+
+        $this->assertSame(
+            array(
+                $spy->curlInitReturnValues[0],
+                CURLOPT_RETURNTRANSFER,
+                true,
+            ),
+            $spy->argsFromCurlSetoptCalls[2],
+            'Should configure curl to return transfer'
+        );
+
+        $this->assertSame(
+            array(
+                $spy->curlInitReturnValues[0],
+                CURLOPT_HTTPHEADER,
+                array('Content-Type: application/json'),
+            ),
+            $spy->argsFromCurlSetoptCalls[3],
+            'Should set Content-Type header to application/json'
+        );
+
+        $this->assertSame(
+            array(
+                $spy->curlInitReturnValues[0],
+                CURLOPT_POST,
+                1,
+            ),
+            $spy->argsFromCurlSetoptCalls[4],
+            'Should send curl request as POST request'
+        );
+
+        $this->assertSame(
+            array(
+                $spy->curlInitReturnValues[0],
+                CURLOPT_HEADER,
+                0,
+            ),
+            $spy->argsFromCurlSetoptCalls[5],
+            'Should not return the header values in the return data'
+        );
+
+        $this->assertSame(
+            array(
+                $spy->curlInitReturnValues[0],
+                CURLOPT_POSTFIELDS,
+                json_encode($expectedVals),
+            ),
+            $spy->argsFromCurlSetoptCalls[6],
+            'Should send JSON-encoded event data as request body'
+        );
+
+        $this->assertSame(
+            array($spy->curlInitReturnValues[0]),
+            $spy->argsFromCurlExecCalls,
+            'Should execute the curl resource'
+        );
+
+        $this->assertSame(
+            array(
+                array(
+                    $spy->curlInitReturnValues[0],
+                    CURLINFO_HTTP_CODE,
+                ),
+            ),
+            $spy->argsFromCurlGetinfoCalls,
+            'Should get the HTTP response code from the curl request'
+        );
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromCurlErrnoCalls),
+            'Should check for curl errors on success'
+        );
+
+        $this->assertSame(
+            array($spy->curlInitReturnValues[0]),
+            $spy->argsFromCurlCloseCalls,
+            'Should close the curl request'
+        );
+
+        $this->assertTrue(
+            $eventSendResult,
+            'Should successfully send event data via curl'
+        );
+    }
+
+    public function testEventFailsWhenCurlReturnsError()
+    {
+        $eventTitle = 'Some event title';
+        $eventVals = array();
+
+        $dog = new DogStatsd($this->getDogStatsdConfigForSendingEventOverCurl());
+
+        $spy = $this->getCurlSpy();
+
+        $spy->curlError = 'some curl error message';
+        $spy->errorNumber = 1; // Any number should cause an exception to throw
+
+        $eventSendSucceeded = $dog->event($eventTitle, $eventVals);
+
+        $this->assertFalse($eventSendSucceeded);
+
+        $this->assertSame(
+            array(
+                sprintf(
+                    'Datadog event API call cURL issue #%s - %s',
+                    $spy->errorNumber,
+                    $spy->curlError
+                ),
+            ),
+            $spy->argsFromErrorLogCalls
+        );
+    }
+
+    public function testEventFailsWhenCurlReturnsNon2xxStatus()
+    {
+        $eventTitle = 'Some event title';
+        $eventVals = array();
+
+        $dog = new DogStatsd($this->getDogStatsdConfigForSendingEventOverCurl());
+
+        $spy = $this->getCurlSpy();
+
+        $spy->responseCode = 500;
+        $spy->responseBody = json_encode(array(
+            'some' => 'data',
+        ));
+
+        $eventSendSucceeded = $dog->event($eventTitle, $eventVals);
+
+        $this->assertFalse($eventSendSucceeded);
+
+        $this->assertSame(
+            array(
+                sprintf(
+                    'Datadog event API call HTTP response not OK - %d; response body: %s',
+                    $spy->responseCode,
+                    $spy->responseBody
+                ),
+            ),
+            $spy->argsFromErrorLogCalls
+        );
+    }
+
+    public function testEventFailsWhenCurlReturnsNoResponseBody()
+    {
+        $eventTitle = 'Some event title';
+        $eventVals = array();
+
+        $dog = new DogStatsd($this->getDogStatsdConfigForSendingEventOverCurl());
+
+        $spy = $this->getCurlSpy();
+
+        $spy->responseCode = 200;
+
+        $eventSendSucceeded = $dog->event($eventTitle, $eventVals);
+
+        $this->assertFalse($eventSendSucceeded);
+
+        $this->assertSame(
+            array(
+                'Datadog event API call did not return a body',
+            ),
+            $spy->argsFromErrorLogCalls
+        );
+    }
+
+    public function testEventFailsWhenCurlReturnsInvalidJSONInResponseBody()
+    {
+        $eventTitle = 'Some event title';
+        $eventVals = array();
+
+        $dog = new DogStatsd($this->getDogStatsdConfigForSendingEventOverCurl());
+
+        $spy = $this->getCurlSpy();
+
+        $spy->responseCode = 200;
+        $spy->responseBody = "{something:{} that isn't valid JSON";
+
+        $eventSendSucceeded = $dog->event($eventTitle, $eventVals);
+
+        $this->assertFalse($eventSendSucceeded);
+
+        $this->assertSame(
+            array(
+                'Datadog event API call did not return a body that could be decoded via json_decode',
+            ),
+            $spy->argsFromErrorLogCalls
+        );
+    }
+
+    /**
+     * Get a timestamp created from a real date that is deterministic in nature
+     *
+     * @return int
+     */
+    private function getDeterministicTimestamp()
+    {
+        $dateTime = DateTime::createFromFormat(
+            DateTime::ATOM,
+            '2018-09-01T4:41:00Z'
+        );
+
+        return $dateTime->getTimestamp();
+    }
+
+    private function getDogStatsdConfigForSendingEventOverCurl()
+    {
+        return array(
+            'api_key' => 'some-api-key',
+            'app_key' => 'some-app-key',
+        );
+    }
+}

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -1,0 +1,809 @@
+<?php
+
+namespace DataDog\UnitTests\DogStatsd;
+
+use DateTime;
+use DataDog\DogStatsd;
+use DataDog\TestHelpers\SocketSpyTestCase;
+
+class SocketsTest extends SocketSpyTestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        // Reset the stubs for mt_rand() and mt_getrandmax()
+        global $mt_rand_stub_return_value;
+        global $mt_getrandmax_stub_return_value;
+        $mt_rand_stub_return_value = null;
+        $mt_getrandmax_stub_return_value = null;
+    }
+
+    public function testTiming()
+    {
+        $stat = 'some.timing_metric';
+        $time = 43;
+        $sampleRate = 1.0;
+        $tags = array('horse' => 'cart');
+        $expectedUdpMessage = 'some.timing_metric:43|ms|#horse:cart';
+
+        $dog = new DogStatsd(array());
+
+        $dog->timing(
+            $stat,
+            $time,
+            $sampleRate,
+            $tags
+        );
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+
+        $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendTo[1]
+        );
+    }
+
+    public function testMicrotiming()
+    {
+        $stat = 'some.microtiming_metric';
+        $time = 26;
+        $sampleRate = 1.0;
+        $tags = array('tuba' => 'solo');
+        $expectedUdpMessage = 'some.microtiming_metric:26000|ms|#tuba:solo';
+
+        $dog = new DogStatsd(array());
+
+        $dog->microtiming(
+            $stat,
+            $time,
+            $sampleRate,
+            $tags
+        );
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+
+        $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendTo[1]
+        );
+    }
+
+    public function testGauge()
+    {
+        $stat = 'some.gauge_metric';
+        $value = 5;
+        $sampleRate = 1.0;
+        $tags = array('baseball' => 'cap');
+        $expectedUdpMessage = 'some.gauge_metric:5|g|#baseball:cap';
+
+        $dog = new DogStatsd(array());
+
+        $dog->gauge(
+            $stat,
+            $value ,
+            $sampleRate,
+            $tags
+        );
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+
+        $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendTo[1]
+        );
+    }
+
+    public function testHistogram()
+    {
+        $stat = 'some.histogram_metric';
+        $value = 109;
+        $sampleRate = 1.0;
+        $tags = array('happy' => 'days');
+        $expectedUdpMessage = 'some.histogram_metric:109|h|#happy:days';
+
+        $dog = new DogStatsd(array());
+
+        $dog->histogram(
+            $stat,
+            $value ,
+            $sampleRate,
+            $tags
+        );
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+
+        $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendTo[1]
+        );
+    }
+
+    public function testDistribution()
+    {
+        $stat = 'some.distribution_metric';
+        $value = 7;
+        $sampleRate = 1.0;
+        $tags = array('floppy' => 'hat');
+        $expectedUdpMessage = 'some.distribution_metric:7|d|#floppy:hat';
+
+        $dog = new DogStatsd(array());
+
+        $dog->distribution(
+            $stat,
+            $value ,
+            $sampleRate,
+            $tags
+        );
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+
+        $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendTo[1]
+        );
+    }
+
+    public function testSet()
+    {
+        $stat = 'some.set_metric';
+        $value = 22239;
+        $sampleRate = 1.0;
+        $tags = array('little' => 'bit');
+        $expectedUdpMessage = 'some.set_metric:22239|s|#little:bit';
+
+        $dog = new DogStatsd(array());
+
+        $dog->set(
+            $stat,
+            $value ,
+            $sampleRate,
+            $tags
+        );
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+
+        $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendTo[1]
+        );
+    }
+
+    /**
+     * @dataProvider serviceCheckProvider
+     * @param $name
+     * @param $status
+     * @param $tags
+     * @param $hostname
+     * @param $message
+     * @param $timestamp
+     * @param $expectedUdpMessage
+     */
+    public function testServiceCheck(
+        $name,
+        $status,
+        $tags,
+        $hostname,
+        $message,
+        $timestamp,
+        $expectedUdpMessage
+    ) {
+        $dog = new DogStatsd(array());
+
+        $dog->service_check(
+            $name,
+            $status,
+            $tags,
+            $hostname,
+            $message,
+            $timestamp
+        );
+
+        $spy = $this->getSocketSpy();
+
+        $argsPassedToSocketSendto = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendto[1]
+        );
+    }
+
+    public function serviceCheckProvider()
+    {
+        $name = 'neat-service';
+        $status = DogStatsd::CRITICAL;
+        $tags = array('red' => 'balloon', 'green' => 'ham');
+        $hostname = 'some-host.com';
+        $message = 'Important message';
+        $timestamp = $this->getDeterministicTimestamp();
+
+        return array(
+            'all arguments provided' => array(
+                $name,
+                $status,
+                $tags,
+                $hostname,
+                $message,
+                $timestamp,
+                '_sc|neat-service|2|d:1535776860|h:some-host.com|#red:balloon,green:ham|m:Important message',
+            ),
+            'without tags' => array(
+                $name,
+                $status,
+                null,
+                $hostname,
+                $message,
+                $timestamp,
+                '_sc|neat-service|2|d:1535776860|h:some-host.com|m:Important message',
+            ),
+            'without hostname' => array(
+                $name,
+                $status,
+                $tags,
+                null,
+                $message,
+                $timestamp,
+                '_sc|neat-service|2|d:1535776860|#red:balloon,green:ham|m:Important message',
+            ),
+            'without message' => array(
+                $name,
+                $status,
+                $tags,
+                $hostname,
+                null,
+                $timestamp,
+                '_sc|neat-service|2|d:1535776860|h:some-host.com|#red:balloon,green:ham',
+            ),
+            'without timestamp' => array(
+                $name,
+                $status,
+                $tags,
+                $hostname,
+                $message,
+                null,
+                '_sc|neat-service|2|h:some-host.com|#red:balloon,green:ham|m:Important message',
+            ),
+        );
+    }
+
+    public function testSend()
+    {
+        $data = array(
+            'foo.metric' => '893|s',
+            'bar.metric' => '4|s'
+        );
+        $sampleRate = 1.0;
+        $tags = array(
+            'cowboy' => 'hat'
+        );
+
+        $expectedUdpMessage1 = 'foo.metric:893|s|#cowboy:hat';
+        $expectedUdpMessage2 = 'bar.metric:4|s|#cowboy:hat';
+
+        $dog = new DogStatsd(array());
+
+        $dog->send($data, $sampleRate, $tags);
+
+        $spy = $this->getSocketSpy();
+
+        $argsPassedToSocketSendtoCall1 = $spy->argsFromSocketSendtoCalls[0];
+        $argsPassedToSocketSendtoCall2 = $spy->argsFromSocketSendtoCalls[1];
+
+        $this->assertSame(
+            2,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 2 UDP messages'
+        );
+
+        $this->assertSame(
+            $expectedUdpMessage1,
+            $argsPassedToSocketSendtoCall1[1],
+            'First UDP message should be correct'
+        );
+
+        $this->assertSame(
+            $expectedUdpMessage2,
+            $argsPassedToSocketSendtoCall2[1],
+            'Second UDP message should be correct'
+        );
+    }
+
+    public function testSendSerializesTagAsString()
+    {
+        $data = array(
+            'foo.metric' => '82|s',
+        );
+        $sampleRate = 1.0;
+        $tag = 'string:tag';
+
+        $expectedUdpMessage = 'foo.metric:82|s|#string:tag';
+
+        $dog = new DogStatsd(array());
+
+        $dog->send($data, $sampleRate, $tag);
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $spy->argsFromSocketSendtoCalls[0][1],
+            'Should serialize tag passed as string'
+        );
+    }
+
+    public function testSendSerializesMessageWithoutTags()
+    {
+        $data = array(
+            'foo.metric' => '19872|h',
+        );
+        $sampleRate = 1.0;
+        $tag = null;
+
+        $expectedUdpMessage = 'foo.metric:19872|h';
+
+        $dog = new DogStatsd(array());
+
+        $dog->send($data, $sampleRate, $tag);
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $spy->argsFromSocketSendtoCalls[0][1],
+            'Should serialize message when no tags are provided'
+        );
+    }
+
+    public function testSendReturnsEarlyWhenPassedEmptyData()
+    {
+        $dog = new DogStatsd(array());
+
+        $dog->send(array());
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            0,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should not send UDP message when event data is empty'
+        );
+    }
+
+    public function testSendSendsWhenRandCalculationLessThanSampleRate()
+    {
+        global $mt_rand_stub_return_value;
+        global $mt_getrandmax_stub_return_value;
+
+        // 0.333 will be less than the sample rate, 0.5
+        $mt_rand_stub_return_value = 1;
+        $mt_getrandmax_stub_return_value = 3;
+
+        $data = array(
+            'foo.metric' => '469|s'
+        );
+        $sampleRate = 0.5;
+
+        $dog = new DogStatsd(array());
+
+        $dog->send($data, $sampleRate);
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+    }
+
+    public function testSendSendsWhenRandCalculationEqualToSampleRate()
+    {
+        global $mt_rand_stub_return_value;
+        global $mt_getrandmax_stub_return_value;
+
+        // 1/2 will be equal to the sample rate, 0.5
+        $mt_rand_stub_return_value = 1;
+        $mt_getrandmax_stub_return_value = 2;
+
+        $data = array(
+            'foo.metric' => '23|g'
+        );
+        $sampleRate = 0.5;
+
+        $dog = new DogStatsd(array());
+
+        $dog->send($data, $sampleRate);
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+    }
+
+    public function testSendDoesNotSendWhenRandCalculationGreaterThanSampleRate()
+    {
+        global $mt_rand_stub_return_value;
+        global $mt_getrandmax_stub_return_value;
+
+        // 1/1 will be greater than the sample rate, 0.5
+        $mt_rand_stub_return_value = 1;
+        $mt_getrandmax_stub_return_value = 1;
+
+        $data = array(
+            'foo.metric' => '23|g'
+        );
+        $sampleRate = 0.5;
+
+        $dog = new DogStatsd(array());
+
+        $dog->send($data, $sampleRate);
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            0,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should not send a UDP message'
+        );
+    }
+
+    public function testIncrement()
+    {
+        $stats = array(
+            'foo.metric',
+        );
+
+        $expectedUdpMessage = 'foo.metric:1|c';
+
+        $dog = new DogStatsd(array());
+
+        $dog->increment($stats);
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+
+        $argsPassedToSocketSendto = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendto[1],
+            'Should send the expected message'
+        );
+    }
+
+    public function testDecrement()
+    {
+        $stats = array(
+            'foo.metric',
+        );
+
+        $expectedUdpMessage = 'foo.metric:-1|c';
+
+        $dog = new DogStatsd(array());
+
+        $dog->decrement($stats);
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+
+        $argsPassedToSocketSendto = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendto[1],
+            'Should send the expected message'
+        );
+    }
+
+    public function testUpdateStats()
+    {
+        $stats = array(
+            'foo.metric',
+            'bar.metric',
+        );
+        $delta = 3;
+        $sampleRate = 1.0;
+        $tags = array(
+            'every' => 'day',
+        );
+
+        $expectedUdpMessage1 = 'foo.metric:3|c|#every:day';
+        $expectedUdpMessage2 = 'bar.metric:3|c|#every:day';
+
+        $dog = new DogStatsd(array());
+
+        $dog->updateStats($stats, $delta, $sampleRate, $tags);
+
+        $spy = $this->getSocketSpy();
+
+        $argsPassedToSocketSendto = $spy->argsFromSocketSendtoCalls;
+
+        $this->assertSame(
+            2,
+            count($argsPassedToSocketSendto),
+            'Should send 2 UDP messages'
+        );
+
+        $this->assertSame(
+            $expectedUdpMessage1,
+            $argsPassedToSocketSendto[0][1],
+            'Should send the expected message for the first call'
+        );
+
+        $this->assertSame(
+            $expectedUdpMessage2,
+            $argsPassedToSocketSendto[1][1],
+            'Should send the expected message for the first call'
+        );
+    }
+
+    public function testUpdateStatsWithStringMetric()
+    {
+        $stats = 'foo.metric';
+        $delta = -45;
+        $sampleRate = 1.0;
+        $tags = array(
+            'long' => 'walk',
+        );
+
+        $expectedUdpMessage = 'foo.metric:-45|c|#long:walk';
+
+        $dog = new DogStatsd(array());
+
+        $dog->updateStats($stats, $delta, $sampleRate, $tags);
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+
+        $argsPassedToSocketSendto = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendto[1],
+            'Should send the expected message'
+        );
+    }
+
+    public function testReport()
+    {
+        $expectedUdpMessage = 'some fake UDP message';
+
+        $dog = new DogStatsd(array());
+
+        $dog->report($expectedUdpMessage);
+
+        $spy = $this->getSocketSpy();
+
+        $argsPassedToSocketSendto = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendto[1]
+        );
+
+        $this->assertSame(
+            strlen($expectedUdpMessage),
+            $argsPassedToSocketSendto[2]
+        );
+    }
+
+    public function testFlush()
+    {
+        $expectedUdpMessage = 'foo';
+
+        $dog = new DogStatsd(array());
+
+        $dog->flush($expectedUdpMessage);
+
+        $spy = $this->getSocketSpy();
+
+        $socketCreateReturnValue = $spy->socketCreateReturnValues[0];
+
+        $this->assertCount(
+            1,
+            $spy->argsFromSocketCreateCalls,
+            'Should call socket_create once'
+        );
+
+        $this->assertSame(
+            array(AF_INET, SOCK_DGRAM, SOL_UDP),
+            $spy->argsFromSocketCreateCalls[0],
+            'Should create a UDP socket to send datagrams over IPv4'
+        );
+
+        $this->assertCount(
+            1,
+            $spy->argsFromSocketSetNonblockCalls,
+            'Should call socket_set_nonblock once'
+        );
+
+        $this->assertSame(
+            $socketCreateReturnValue,
+            $spy->argsFromSocketSetNonblockCalls[0],
+            'Should call socket_set_nonblock once with the socket previously created'
+        );
+
+        $this->assertCount(
+            1,
+            $spy->argsFromSocketSendtoCalls,
+            'Should call socket_sendto once'
+        );
+
+        $this->assertSame(
+            array(
+                $socketCreateReturnValue,
+                $expectedUdpMessage,
+                strlen($expectedUdpMessage),
+                0,
+                'localhost',
+                8125
+            ),
+            $spy->argsFromSocketSendtoCalls[0],
+            'Should send the expected message to localhost:8125'
+        );
+
+        $this->assertCount(
+            1,
+            $spy->argsFromSocketCloseCalls,
+            'Should call socket_close once'
+        );
+
+        $this->assertSame(
+            $socketCreateReturnValue,
+            $spy->socketCreateReturnValues[0],
+            'Should close the socket previously created'
+        );
+    }
+
+    public function testEventUdp()
+    {
+        $eventTitle = 'Some event title';
+        $eventVals = array(
+            'text'             => "Some event text\nthat spans 2 lines",
+            'date_happened'    => $this->getDeterministicTimestamp(),
+            'hostname'         => 'some.host.com',
+            'aggregation_key'  => '83e2cf',
+            'priority'         => 'normal',
+            'source_type_name' => 'jenkins',
+            'alert_type'       => 'warning',
+            'tags'             => array (
+                'chicken' => 'nachos',
+            ),
+        );
+
+        $expectedUdpMessage = "_e{16,34}:Some event title|Some event text\\nthat spans 2 lines|d:1535776860|h:some.host.com|k:83e2cf|p:normal|s:jenkins|t:warning|#chicken:nachos";
+
+        $dog = new DogStatsd(array());
+
+        $dog->event($eventTitle, $eventVals);
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+
+        $argsPassedToSocketSendto = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendto[1]
+        );
+    }
+
+    /**
+     * @todo This test is technically correct, but it points out a flaw in
+     *       the way events are handled. It is probably best to return early
+     *       and avoid sending an empty event payload if no meaningful data
+     *       is passed.
+     */
+    public function testEventUdpWithEmptyValues()
+    {
+        $eventTitle = '';
+
+        $expectedUdpMessage = "_e{0,0}:|";
+
+        $dog = new DogStatsd(array());
+
+        $dog->event($eventTitle);
+
+        $spy = $this->getSocketSpy();
+
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+
+        $argsPassedToSocketSendto = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSame(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendto[1]
+        );
+    }
+
+    /**
+     * Get a timestamp created from a real date that is deterministic in nature
+     *
+     * @return int
+     */
+    private function getDeterministicTimestamp()
+    {
+        $dateTime = DateTime::createFromFormat(
+            DateTime::ATOM,
+            '2018-09-01T4:41:00Z'
+        );
+
+        return $dateTime->getTimestamp();
+    }
+}

--- a/tests/curl_and_error_log_function_stubs.php
+++ b/tests/curl_and_error_log_function_stubs.php
@@ -1,0 +1,129 @@
+<?php
+
+/**
+ * Stubbed versions of curl functions, and error_log
+ *
+ * Useful for testing DataDog\DogStatsd::event without actually sending HTTP
+ * request, and without invoking the real error_log function.
+ *
+ * @see \DataDog\TestHelpers\CurlSpy
+ * @see \DataDog\TestHelpers\CurlSpyTestCase
+ */
+
+namespace DataDog;
+
+/**
+ * Stub of built in global PHP function curl_init
+ *
+ * @param string|null $url
+ * @return resource
+ */
+function curl_init($url = null)
+{
+    global $curlSpy;
+
+    $curlSpy->curlInitWasCalledWithArg($url);
+
+    $resource = fopen('/dev/null', 'r');
+
+    $curlSpy->curlInitDidReturn($resource);
+
+    return $resource;
+}
+
+/**
+ * Stub of built in global PHP function curl_setopt
+ *
+ * @param resource $ch
+ * @param int $option
+ * @param mixed $value
+ */
+function curl_setopt($ch, $option, $value)
+{
+    global $curlSpy;
+
+    $curlSpy->curlSetoptWasCalledWithArgs($ch, $option, $value);
+}
+
+/**
+ * Stub of built in global PHP function curl_exec
+ *
+ * @param resource $ch
+ * @return mixed
+ */
+function curl_exec($ch)
+{
+    global $curlSpy;
+
+    $curlSpy->curlExecCalledWithArg($ch);
+
+    return $curlSpy->responseBody;
+}
+
+/**
+ * Stub of built in global PHP function curl_getinfo
+ *
+ * @param resource $ch
+ * @param int $opt
+ * @return int
+ */
+function curl_getinfo($ch, $opt)
+{
+    global $curlSpy;
+
+    $curlSpy->curlGetinfoCalledWithArgs($ch, $opt);
+
+    return $curlSpy->responseCode;
+}
+
+/**
+ * Stub of built in global PHP function curl_errno
+ *
+ * @param resource $ch
+ * @return int
+ */
+function curl_errno($ch)
+{
+    global $curlSpy;
+
+    $curlSpy->curlErrnoCalledWithArg($ch);
+
+    return $curlSpy->errorNumber;
+}
+
+/**
+ * Stub of built in global PHP function curl_close
+ *
+ * @param resource $ch
+ */
+function curl_close($ch)
+{
+    global $curlSpy;
+
+    $curlSpy->curlCloseCalledWithArg($ch);
+}
+
+/**
+ * Stub of built in global PHP function curl_error
+ *
+ * @param resource $ch
+ * @return string
+ */
+function curl_error($ch)
+{
+    global $curlSpy;
+
+    $curlSpy->curlErrorCalledWithArg($ch);
+
+    return $curlSpy->curlError;
+}
+
+/**
+ * @param string $message
+ */
+function error_log($message)
+{
+    global $curlSpy;
+
+    $curlSpy->errorLogCallsWithArg($message);
+}

--- a/tests/mt_rand_function_stubs.php
+++ b/tests/mt_rand_function_stubs.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Stubbed versions of mt_rand functions
+ *
+ * Useful for testing DataDog\DogStatsd::send with deterministic values.
+ *
+ * @see \DataDog\UnitTests\DogStatsd\SocketsTest
+ */
+
+namespace DataDog;
+
+/**
+ * Making this variable global to this file is necessary for interacting with
+ * the stubbed global functions below.
+ */
+$mt_rand_stub_return_value = null;
+
+/**
+ * Stub of global built in function mt_rand()
+ *
+ * Useful for testing sampling with deterministic values.
+ *
+ * @return int|null
+ */
+function mt_rand()
+{
+    global $mt_rand_stub_return_value;
+
+    if (is_null($mt_rand_stub_return_value)) {
+        return \mt_rand();
+    }
+
+    return $mt_rand_stub_return_value;
+}
+
+/**
+ * Making this variable global to this file is necessary for interacting with
+ * the stubbed global functions below.
+ */
+$mt_getrandmax_stub_return_value = null;
+
+/**
+ * Stub of global built in function mt_getrandmax()
+ *
+ * Useful for testing sampling with deterministic values.
+ *
+ * @return int|null
+ */
+function mt_getrandmax()
+{
+    global $mt_getrandmax_stub_return_value;
+
+    if (is_null($mt_getrandmax_stub_return_value)) {
+        return \mt_getrandmax();
+    }
+
+    return $mt_getrandmax_stub_return_value;
+}

--- a/tests/socket_function_stubs.php
+++ b/tests/socket_function_stubs.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * Stubbed versions of socket functions
+ *
+ * Useful for testing DataDog\DogStatsd::send without actually attempting to
+ * send data over a socket.
+ *
+ * @see \DataDog\UnitTests\DogStatsd\SocketsTest
+ * @see \DataDog\TestHelpers\SocketSpy
+ * @see \DataDog\TestHelpers\SocketSpyTestCase
+ */
+
+namespace DataDog;
+
+/**
+ * Stub of built in global PHP function socket_create
+ *
+ * @param int $domain
+ * @param int $type
+ * @param int $protocol
+ * @return resource
+ */
+function socket_create($domain, $type, $protocol)
+{
+    global $socketSpy;
+
+    $socketSpy->socketCreateWasCalledWithArgs($domain, $type, $protocol);
+
+    // A PHP resource of unimportance, useful primarily to assert that our stubs
+    // of the global socket functions return or take a deterministic value.
+    $resource = fopen('/dev/null', 'r');
+
+    $socketSpy->socketCreateDidReturn($resource);
+
+    return $resource;
+}
+
+/**
+ * Stub of built in global PHP function socket_set_nonblock
+ *
+ * @param resource $socket
+ */
+function socket_set_nonblock($socket)
+{
+    global $socketSpy;
+
+    $socketSpy->socketSetNonblockWasCalledWithArg($socket);
+}
+
+/**
+ * Stub of built in global PHP function socket_sendto
+ *
+ * @param resource $socket
+ * @param string $buf
+ * @param int $len
+ * @param int $flags
+ * @param string $addr
+ * @param int $port
+ */
+function socket_sendto($socket, $buf, $len, $flags, $addr, $port)
+{
+    global $socketSpy;
+
+    $socketSpy->socketSendtoWasCalledWithArgs($socket, $buf, $len, $flags, $addr, $port);
+}
+
+/**
+ * Stub of built in global PHP function socket_close
+ *
+ * @param resource $socket
+ */
+function socket_close($socket)
+{
+    global $socketSpy;
+
+    $socketSpy->socketCloseWasCalled($socket);
+}


### PR DESCRIPTION
This PR installs and configures PHPUnit. In addition, it adds unit tests.

Thanks, looking forward to your feedback!

*EDIT*: I am now running PHPUnit tests in Travis. However, in order to support versions of PHP all the way back to PHP 5.3, I installed a rather old version of PHPUnit. This isn't ideal; some code in the older version of PHPUnit calls deprecated functions. See https://travis-ci.org/DataDog/php-datadogstatsd/jobs/423273440 for an example of the deprecation warnings.

If those deprecation warnings seem problematic, PHPUnit could be upgraded to a more recent version (say, to 5.7.x, which supports PHP5.6+), and then Travis failures could be suppressed on a per-version basis. For example: https://github.com/sebastianbergmann/phpunit/blob/master/.travis.yml#L16