### PR TITLE
Remove comment that is far from true now

### DIFF
--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -4,7 +4,6 @@ namespace DataDog;
 
 /**
  * Datadog implementation of StatsD
- * - Most of this code was stolen from: https://gist.github.com/1065177/5f7debc212724111f9f500733c626416f9f54ee6
  **/
 
 class DogStatsd


### PR DESCRIPTION
This PR removes a comment that may have been true some years ago, but is most certainly no longer true now. The gist this comment references still exists, but if it still feels correct to credit that gist, a better place to do it might be in the README? In any event, this library has come a long way from its humble gist origins. 😄 