### PR TITLE
Fix link to event documentation

### DIFF
--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -326,7 +326,7 @@ class DogStatsd
      *
      * @param string $title Title of the event
      * @param array $vals Optional values of the event. See
-     *   http://docs.datadoghq.com/guides/dogstatsd/#events for the valid keys
+     *   https://docs.datadoghq.com/api/?lang=bash#post-an-event for the valid keys
      * @return null
      **/
     public function event($title, $vals = array())
@@ -409,7 +409,7 @@ class DogStatsd
     /**
      * Formats $vals array into event for submission to Datadog via UDP
      * @param array $vals Optional values of the event. See
-     *   http://docs.datadoghq.com/guides/dogstatsd/#events for the valid keys
+     *   https://docs.datadoghq.com/api/?lang=bash#post-an-event for the valid keys
      * @return null
      */
     private function eventUdp($vals)


### PR DESCRIPTION
Link is outdated and points to general statsd page.