### PR TITLE
Update extension requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,10 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "ext-curl": "*",
         "lib-curl": "*"
+    },
+    "suggest": {
+        "ext-curl": "*"
     },
     "support": {
         "email": "package@datadoghq.com",


### PR DESCRIPTION
As far as I can tell ever since #31 `ext-curl` is not used in the default configuration. As such it should be marked optional.