### PR TITLE
Adding ext-sockets as requirement in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require": {
         "php": ">=5.3.0",
         "ext-curl": "*",
-        "lib-curl": "*"
+        "lib-curl": "*",
+        "ext-sockets": "*"
     },
     "support": {
         "email": "package@datadoghq.com",


### PR DESCRIPTION
The sockets extension must be enabled for DogStatsd to work.