### PR TITLE
add env vars support for dogstatsd host, port and entity id

### DIFF
--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -69,8 +69,8 @@ class DogStatsd
      */
     public function __construct(array $config = array())
     {
-        $this->host = isset($config['host']) ? $config['host'] : 'localhost';
-        $this->port = isset($config['port']) ? $config['port'] : 8125;
+        $this->host = isset($config['host']) ? $config['host'] : (getenv('DD_AGENT_HOST') ? getenv('DD_AGENT_HOST') : 'localhost');
+        $this->port = isset($config['port']) ? $config['port'] : (getenv('DD_DOGSTATSD_PORT') ? (int)getenv('DD_DOGSTATSD_PORT') : 8125);
         $this->socketPath = isset($config['socket_path']) ? $config['socket_path'] : null;
 
         $this->datadogHost = isset($config['datadog_host']) ? $config['datadog_host'] : 'https://app.datadoghq.com';
@@ -81,6 +81,9 @@ class DogStatsd
         $this->appKey = isset($config['app_key']) ? $config['app_key'] : null;
 
         $this->globalTags = isset($config['global_tags']) ? $config['global_tags'] : array();
+        if (getenv('DD_ENTITY_ID')) {
+            $this->globalTags['dd.internal.entity_id'] = getenv('DD_ENTITY_ID');
+        }
 
         if ($this->apiKey !== null) {
             $this->submitEventsOver = 'TCP';

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -33,12 +33,12 @@ class SocketsTest extends SocketSpyTestCase
         $dog = new DogStatsd(array());
         $this->assertSame(
             'myenvvarhost',
-            self::getPrivate($dog, host),
+            self::getPrivate($dog, 'host'),
             'Should retrieve host from env var'
         );
         $this->assertSame(
             1234,
-            self::getPrivate($dog, port),
+            self::getPrivate($dog, 'port'),
             'Should retrieve port from env var'
         );
         putenv("DD_AGENT_HOST");
@@ -55,12 +55,12 @@ class SocketsTest extends SocketSpyTestCase
         ));
         $this->assertSame(
             'myhost',
-            self::getPrivate($dog, host),
+            self::getPrivate($dog, 'host'),
             'Should retrieve host from args not env var'
         );
         $this->assertSame(
             4321,
-            self::getPrivate($dog, port),
+            self::getPrivate($dog, 'port'),
             'Should retrieve port from args not env var'
         );
         putenv("DD_AGENT_HOST");
@@ -72,12 +72,12 @@ class SocketsTest extends SocketSpyTestCase
         $dog = new DogStatsd(array());
         $this->assertSame(
             'localhost',
-            self::getPrivate($dog, host),
+            self::getPrivate($dog, 'host'),
             'Should retrieve defaulthost'
         );
         $this->assertSame(
             8125,
-            self::getPrivate($dog, port),
+            self::getPrivate($dog, 'port'),
             'Should retrieve default port'
         );
     }


### PR DESCRIPTION
Add environment variables support for Client configuration

Support of 3 environment variables for Client configuration:

`"DD_AGENT_HOST"` used to provide the Agent hostname.
`"DD_DOGSTATSD_PORT"` used to provide the DogStatsD port.
`"DD_ENTITY_ID"` used to provide an identifier to the Client.


If Client constructor's arguments are not set, prioritize `"DD_AGENT_HOST"` and `"DD_DOGSTATSD_PORT"` over default values.
Add `"DD_ENTITY_ID"` to tags with the tag name `dd.internal.entity_id`.