### PR TITLE
origin detection documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ $statsd->event('Now it is fixed.',
 - Logging on communication errors with Datadog (uses cURL for API request)
 - Logs via error_log and try/catch block to not throw warnings/errors on communication issues with API
 
-### Origin detection over UDP
+### Origin detection over UDP in Kubernetes
 
 Origin detection is a method to detect which pod DogStatsD packets are coming from in order to add the pod's tags to the tag list.
 
@@ -179,6 +179,7 @@ env:
         fieldPath: metadata.uid
 ```
 The DogStatsD client attaches an internal tag, `entity_id`. The value of this tag is the content of the `DD_ENTITY_ID` environment variable, which is the pod’s UID.
+The agent uses this tag to infer packets' origin, and tag their metrics accordingly.
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,20 @@ $statsd->event('Now it is fixed.',
 - Logging on communication errors with Datadog (uses cURL for API request)
 - Logs via error_log and try/catch block to not throw warnings/errors on communication issues with API
 
+### Origin detection over UDP
+
+Origin detection is a method to detect which pod DogStatsD packets are coming from in order to add the pod's tags to the tag list.
+
+To enable origin detection over UDP, add the following lines to your application manifest
+```yaml
+env:
+  - name: DD_ENTITY_ID
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.uid
+```
+The DogStatsD client attaches an internal tag, `entity_id`. The value of this tag is the content of the `DD_ENTITY_ID` environment variable, which is the pod’s UID.
+
 ## Roadmap
 
 - Add a configurable timeout for event submission via TCP


### PR DESCRIPTION
Document the origin detection feature introduced by https://github.com/DataDog/php-datadogstatsd/pull/83 with an example of how to set up the `DD_ENTITY_ID` env var.