### PR TITLE
Set correct properties from curl_ssl_verify_host/curl_ssl_verify_peer

### DIFF
--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -74,8 +74,8 @@ class DogStatsd
         $this->socketPath = isset($config['socket_path']) ? $config['socket_path'] : null;
 
         $this->datadogHost = isset($config['datadog_host']) ? $config['datadog_host'] : 'https://app.datadoghq.com';
-        $this->apiCurlSslVerifyHost = isset($config['curl_ssl_verify_host']) ? $config['curl_ssl_verify_host'] : 2;
-        $this->apiCurlSslVerifyPeer = isset($config['curl_ssl_verify_peer']) ? $config['curl_ssl_verify_peer'] : 1;
+        $this->curlVerifySslHost = isset($config['curl_ssl_verify_host']) ? $config['curl_ssl_verify_host'] : 2;
+        $this->curlVerifySslPeer = isset($config['curl_ssl_verify_peer']) ? $config['curl_ssl_verify_peer'] : 1;
 
         $this->apiKey = isset($config['api_key']) ? $config['api_key'] : null;
         $this->appKey = isset($config['app_key']) ? $config['app_key'] : null;


### PR DESCRIPTION
Small config fix when setting `curlVerifySslHost` / `curlVerifySslPeer `.

Note: This probably means `null` is being interpreted as `false`/`0` in the current implementation.