### PR TITLE
Number format regardless of locale

### DIFF
--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -576,15 +576,15 @@ class DogStatsd
      *
      * @return string Formatted value
      */
-    protected function normalizeStat($value) {
+    function normalizeStat($value) {
       // Controlls the way things are converted to a string.
       // Otherwise localization settings impact float to string conversion (e.x 1.3 -> 1,3 and 10000 => 10,000)
-      $string_representation = rtrim(number_format($value, $this->decimalPrecision, '.', ''), "0");
-      $value_len = strlen($string_representation);
-      $last_char = substr($value_len - 1, $value_len, $string_representation);
+      $string_representation = rtrim(number_format($value, 5, '.', ''), "0");
+      $last_char = substr($string_representation, -1, 1);
       if ($last_char == '.') {
-        $string_representation = substr(0, $value_len - 1, $string_representation);
+        $string_representation = substr($string_representation, 0, strlen($string_representation) - 1);
       }
       return $string_representation;
     }
+
 }

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -579,12 +579,7 @@ class DogStatsd
     function normalizeStat($value) {
       // Controlls the way things are converted to a string.
       // Otherwise localization settings impact float to string conversion (e.x 1.3 -> 1,3 and 10000 => 10,000)
-      $string_representation = rtrim(number_format($value, 5, '.', ''), "0");
-      $last_char = substr($string_representation, -1, 1);
-      if ($last_char == '.') {
-        $string_representation = substr($string_representation, 0, strlen($string_representation) - 1);
-      }
-      return $string_representation;
+      return rtrim(trim(number_format($value, $this->decimalPrecision, '.', ''), "0"), ".");
     }
 
 }

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -577,14 +577,12 @@ class DogStatsd
      * @return string Formatted value
      */
     protected function normalizeStat($value) {
-      echo 'Preformat:  ' . $value . PHP_EOL;
       // Controlls the way things are converted to a string.
       // Otherwise localization settings impact float to string conversion (e.x 1.3 -> 1,3 and 10000 => 10,000)
       // If one would rather control formatting themselves adn dont want to override the class, they can pass in a string
       if (is_string($value)) {
         return $value;
       }
-      echo 'Postformat:  ' . number_format($value, $this->decimalPrecision, '.', '') . PHP_EOL;
       return number_format($value, $this->decimalPrecision, '.', '');
     }
 }

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -577,12 +577,14 @@ class DogStatsd
      * @return string Formatted value
      */
     protected function normalizeStat($value) {
+      echo 'Preformat:  ' . $value . PHP_EOL;
       // Controlls the way things are converted to a string.
       // Otherwise localization settings impact float to string conversion (e.x 1.3 -> 1,3 and 10000 => 10,000)
       // If one would rather control formatting themselves adn dont want to override the class, they can pass in a string
-      if is_string($value) {
+      if (is_string($value)) {
         return $value;
       }
+      echo 'Postformat:  ' . number_format($value, $this->decimalPrecision, '.', '') . PHP_EOL;
       return number_format($value, $this->decimalPrecision, '.', '');
     }
 }

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -580,7 +580,7 @@ class DogStatsd
       // Controlls the way things are converted to a string.
       // Otherwise localization settings impact float to string conversion (e.x 1.3 -> 1,3 and 10000 => 10,000)
       // If one would rather control formatting themselves adn dont want to override the class, they can pass in a string
-      if (is_string($value)) {
+      if (!is_float($value)) {
         return $value;
       }
       return number_format($value, $this->decimalPrecision, '.', '');

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -73,6 +73,7 @@ class DogStatsd
      * api_key and app_key
      *
      * @param array $config
+     * @param int   $decimal_precision
      */
     public function __construct(array $config = array(), $decimal_precision = 5)
     {
@@ -568,6 +569,13 @@ class DogStatsd
         return null;
     }
 
+    /**
+     * Normalize the value witout locale consideration before queuing the metric for sending
+     *
+     * @param string $value The value to normalize
+     *
+     * @return string Formatted value
+     */
     protected function normalizeStat($value) {
       // Controlls the way things are converted to a string.
       // Otherwise localization settings impact float to string conversion (e.x 1.3 -> 1,3 and 10000 => 10,000)

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -141,6 +141,7 @@ class DogStatsd
      */
     public function timing($stat, $time, $sampleRate = 1.0, $tags = null)
     {
+        $time = $this->normalizeStat($time);
         $this->send(array($stat => "$time|ms"), $sampleRate, $tags);
     }
 
@@ -169,6 +170,7 @@ class DogStatsd
      **/
     public function gauge($stat, $value, $sampleRate = 1.0, $tags = null)
     {
+        $value = $this->normalizeStat($value);
         $this->send(array($stat => "$value|g"), $sampleRate, $tags);
     }
 
@@ -183,6 +185,7 @@ class DogStatsd
      **/
     public function histogram($stat, $value, $sampleRate = 1.0, $tags = null)
     {
+        $value = $this->normalizeStat($value);
         $this->send(array($stat => "$value|h"), $sampleRate, $tags);
     }
 
@@ -197,6 +200,7 @@ class DogStatsd
      **/
     public function distribution($stat, $value, $sampleRate = 1.0, $tags = null)
     {
+        $value = $this->normalizeStat($value);
         $this->send(array($stat => "$value|d"), $sampleRate, $tags);
     }
 
@@ -211,6 +215,7 @@ class DogStatsd
      **/
     public function set($stat, $value, $sampleRate = 1.0, $tags = null)
     {
+        $value = $this->normalizeStat($value);
         $this->send(array($stat => "$value|s"), $sampleRate, $tags);
     }
 
@@ -257,6 +262,7 @@ class DogStatsd
      **/
     public function updateStats($stats, $delta = 1, $sampleRate = 1.0, $tags = null)
     {
+        $delta = $this->normalizeStat($delta);
         if (!is_array($stats)) {
             $stats = array($stats);
         }
@@ -554,5 +560,9 @@ class DogStatsd
         $this->report('_e{' . $title_length . ',' . $text_length . '}:' . $fields);
 
         return null;
+    }
+
+    protected function normalizeStat($stat) {
+      return format_number($stat, 999, '.', '');
     }
 }

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -568,17 +568,13 @@ class DogStatsd
         return null;
     }
 
-    protected function normalizeStat($stat) {
-      // Float to string conversion changes by locale (comma instead of decimal e.x. 1.3 => 1,3 and sometimes commas for large integers e.x. 10,000)
-      // Very large numbers get messed up through number_format, to avoid this we break it up into the integer and decimal precision bits.
-      // To avoid different logic based on positive/negative numbers, take the abs and preserve the sign in the stringified output
-      $sign = ($stat < 0) ? '-' : '';
-      $stat = abs($stat);
-      $statInteger = floor($stat);
-      $statPrecision = $stat - $statInteger;
-      $formattedInt = number_format($statInteger, 0, '.', '');
-      // substr trims the preceeding 0 in prepresentation
-      $formattedPrecision = substr(number_format($statPrecision, $this->decimalPrecision, '.', ''), 1);
-      return "${sign}${formattedInt}${formattedPrecision}";
+    protected function normalizeStat($value) {
+      // Controlls the way things are converted to a string.
+      // Otherwise localization settings impact float to string conversion (e.x 1.3 -> 1,3 and 10000 => 10,000)
+      // If one would rather control formatting themselves adn dont want to override the class, they can pass in a string
+      if is_string($value) {
+        return $value;
+      }
+      return number_format($value, $this->decimalPrecision, '.', '');
     }
 }

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -579,6 +579,12 @@ class DogStatsd
     protected function normalizeStat($value) {
       // Controlls the way things are converted to a string.
       // Otherwise localization settings impact float to string conversion (e.x 1.3 -> 1,3 and 10000 => 10,000)
-      return number_format($value, $this->decimalPrecision, '.', '');
+      $string_representation = rtrim(number_format($value, $this->decimalPrecision, '.', ''), "0");
+      $value_len = strlen($string_representation);
+      $last_char = substr($value_len - 1, $value_len, $string_representation);
+      if ($last_char == '.') {
+        $string_representation = substr(0, $value_len - 1, $string_representation);
+      }
+      return $string_representation;
     }
 }

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -70,12 +70,12 @@ class DogStatsd
      * datadog_host,
      * curl_ssl_verify_host,
      * curl_ssl_verify_peer,
-     * api_key and app_key
+     * api_key and app_key,
+     * decimal_precision
      *
      * @param array $config
-     * @param int   $decimal_precision
      */
-    public function __construct(array $config = array(), $decimal_precision = 5)
+    public function __construct(array $config = array())
     {
         $this->host = isset($config['host']) ? $config['host'] : (getenv('DD_AGENT_HOST') ? getenv('DD_AGENT_HOST') : 'localhost');
         $this->port = isset($config['port']) ? $config['port'] : (getenv('DD_DOGSTATSD_PORT') ? (int)getenv('DD_DOGSTATSD_PORT') : 8125);
@@ -88,7 +88,7 @@ class DogStatsd
         $this->apiKey = isset($config['api_key']) ? $config['api_key'] : null;
         $this->appKey = isset($config['app_key']) ? $config['app_key'] : null;
 
-        $this->decimalPrecision = $decimal_precision;
+        $this->decimalPrecision = isset($config['decimal_precision']) ? $config['decimal_precision'] : 2;
 
         $this->globalTags = isset($config['global_tags']) ? $config['global_tags'] : array();
         if (getenv('DD_ENTITY_ID')) {
@@ -579,10 +579,6 @@ class DogStatsd
     protected function normalizeStat($value) {
       // Controlls the way things are converted to a string.
       // Otherwise localization settings impact float to string conversion (e.x 1.3 -> 1,3 and 10000 => 10,000)
-      // If one would rather control formatting themselves adn dont want to override the class, they can pass in a string
-      if (!is_float($value)) {
-        return $value;
-      }
       return number_format($value, $this->decimalPrecision, '.', '');
     }
 }

--- a/tests/UnitTests/BatchedDogStatsdTest.php
+++ b/tests/UnitTests/BatchedDogStatsdTest.php
@@ -45,9 +45,9 @@ class BatchedDogStatsdTest extends SocketSpyTestCase
         $batchedDog::$maxBufferLength = 2;
 
         $udpMessage = 'some fake UDP message';
-        $expectedUdpMessageOnceSent = $udpMessage . "1:21|g\n"
-            . $udpMessage . "2:21|g\n"
-            . $udpMessage . "3:21|g";
+        $expectedUdpMessageOnceSent = $udpMessage . "1:21.00|g\n"
+            . $udpMessage . "2:21.00|g\n"
+            . $udpMessage . "3:21.00|g";
 
         $batchedDog->gauge($udpMessage . '1', 21);
         $batchedDog->gauge($udpMessage . '2', 21);

--- a/tests/UnitTests/BatchedDogStatsdTest.php
+++ b/tests/UnitTests/BatchedDogStatsdTest.php
@@ -45,9 +45,9 @@ class BatchedDogStatsdTest extends SocketSpyTestCase
         $batchedDog::$maxBufferLength = 2;
 
         $udpMessage = 'some fake UDP message';
-        $expectedUdpMessageOnceSent = $udpMessage . "1:21.00|g\n"
-            . $udpMessage . "2:21.00|g\n"
-            . $udpMessage . "3:21.00|g";
+        $expectedUdpMessageOnceSent = $udpMessage . "1:21|g\n"
+            . $udpMessage . "2:21|g\n"
+            . $udpMessage . "3:21|g";
 
         $batchedDog->gauge($udpMessage . '1', 21);
         $batchedDog->gauge($udpMessage . '2', 21);

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -1128,7 +1128,7 @@ class SocketsTest extends SocketSpyTestCase
         $dog->gauge('metric', 42);
 
         $this->assertSameWithTelemetry(
-            'metric:42|g',
+            'metric:42.00|g',
             $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]
         );
     }
@@ -1141,22 +1141,22 @@ class SocketsTest extends SocketSpyTestCase
         $this->assertSameWithTelemetry('test:21.00|ms', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]);
 
         $dog->gauge('test', 21);
-        $this->assertSameWithTelemetry('test:21|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 675, "packets_sent" => 1));
+        $this->assertSameWithTelemetry('test:21.00|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 678, "packets_sent" => 1));
 
         $dog->histogram('test', 21);
-        $this->assertSameWithTelemetry('test:21|h', $this->getSocketSpy()->argsFromSocketSendtoCalls[2][1], "", array("bytes_sent" => 676, "packets_sent" => 1));
+        $this->assertSameWithTelemetry('test:21.00|h', $this->getSocketSpy()->argsFromSocketSendtoCalls[2][1], "", array("bytes_sent" => 679, "packets_sent" => 1));
 
         $dog->distribution('test', 21);
-        $this->assertSameWithTelemetry('test:21|d', $this->getSocketSpy()->argsFromSocketSendtoCalls[3][1], "", array("bytes_sent" => 676, "packets_sent" => 1));
+        $this->assertSameWithTelemetry('test:21.00|d', $this->getSocketSpy()->argsFromSocketSendtoCalls[3][1], "", array("bytes_sent" => 679, "packets_sent" => 1));
 
         $dog->set('test', 21);
-        $this->assertSameWithTelemetry('test:21|s', $this->getSocketSpy()->argsFromSocketSendtoCalls[4][1], "", array("bytes_sent" => 676, "packets_sent" => 1));
+        $this->assertSameWithTelemetry('test:21.00|s', $this->getSocketSpy()->argsFromSocketSendtoCalls[4][1], "", array("bytes_sent" => 679, "packets_sent" => 1));
 
         $dog->increment('test');
-        $this->assertSameWithTelemetry('test:1|c', $this->getSocketSpy()->argsFromSocketSendtoCalls[5][1], "", array("bytes_sent" => 676, "packets_sent" => 1));
+        $this->assertSameWithTelemetry('test:1.00|c', $this->getSocketSpy()->argsFromSocketSendtoCalls[5][1], "", array("bytes_sent" => 679, "packets_sent" => 1));
 
         $dog->decrement('test');
-        $this->assertSameWithTelemetry('test:-1|c', $this->getSocketSpy()->argsFromSocketSendtoCalls[6][1], "", array("bytes_sent" => 675, "packets_sent" => 1));
+        $this->assertSameWithTelemetry('test:-1.00|c', $this->getSocketSpy()->argsFromSocketSendtoCalls[6][1], "", array("bytes_sent" => 678, "packets_sent" => 1));
 
         $dog->event('ev', array('text' => 'text'));
         $this->assertSameWithTelemetry('_e{2,4}:ev|text', $this->getSocketSpy()->argsFromSocketSendtoCalls[7][1], "", array("bytes_sent" => 676, "packets_sent" => 1, "metrics" => 0, "events" => 1));
@@ -1180,7 +1180,7 @@ class SocketsTest extends SocketSpyTestCase
         $this->getSocketSpy()->returnErrorOnSend = false;
 
         $dog->gauge('test', 22);
-        $this->assertSameWithTelemetry('test:22.00|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1], "", array("metrics" => 3, "bytes_dropped" => 1351, "packets_dropped" => 2));
+        $this->assertSameWithTelemetry('test:22.00|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1], "", array("metrics" => 3, "bytes_dropped" => 1357, "packets_dropped" => 2));
 
         # force flush to get the telemetry about the last message sent
         $dog->flush("");

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -1057,34 +1057,6 @@ class SocketsTest extends SocketSpyTestCase
         );
     }
 
-    public function testGlobalTagsWithEntityIdFromEnvVar()
-    {
-        putenv("DD_ENTITY_ID=04652bb7-19b7-11e9-9cc6-42010a9c016d");
-        $dog = new DogStatsd(array(
-            'global_tags' => array(
-                'my_tag' => 'tag_value',
-            ),
-            'disable_telemetry' => false
-        ));
-        $dog->timing('metric', 42, 1.0);
-        $spy = $this->getSocketSpy();
-        $this->assertSame(
-            1,
-            count($spy->argsFromSocketSendtoCalls),
-            'Should send 1 UDP message'
-        );
-        $expectedUdpMessage = 'metric:42.00|ms|#my_tag:tag_value,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d';
-        $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
-
-        $this->assertSameWithTelemetry(
-            $expectedUdpMessage,
-            $argsPassedToSocketSendTo[1],
-            "",
-            array("tags" => "my_tag:tag_value,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d")
-        );
-        putenv("DD_ENTITY_ID=''");
-    }
-
     public function testGlobalTagsAreSupplementedWithLocalTags()
     {
         $dog = new DogStatsd(array(
@@ -1213,6 +1185,34 @@ class SocketsTest extends SocketSpyTestCase
         # force flush to get the telemetry about the last message sent
         $dog->flush("");
         $this->assertSameWithTelemetry('', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 677, "packets_sent" => 1, "metrics" => 0));
+    }
+
+    public function testGlobalTagsWithEntityIdFromEnvVar()
+    {
+        putenv("DD_ENTITY_ID=04652bb7-19b7-11e9-9cc6-42010a9c016d");
+        $dog = new DogStatsd(array(
+            'global_tags' => array(
+                'my_tag' => 'tag_value',
+            ),
+            'disable_telemetry' => false
+        ));
+        $dog->timing('metric', 42, 1.0);
+        $spy = $this->getSocketSpy();
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+        $expectedUdpMessage = 'metric:42.00|ms|#my_tag:tag_value,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d';
+        $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSameWithTelemetry(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendTo[1],
+            "",
+            array("tags" => "my_tag:tag_value,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d")
+        );
+        putenv("DD_ENTITY_ID");
     }
 
     /**

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -454,7 +454,7 @@ class SocketsTest extends SocketSpyTestCase
             $expectedUdpMessage2,
             $argsPassedToSocketSendtoCall2[1],
             'Second UDP message should be correct',
-            array("bytes_sent" => 693, "packets_sent" => 1)
+            array("bytes_sent" => 696, "packets_sent" => 1)
         );
     }
 
@@ -466,7 +466,7 @@ class SocketsTest extends SocketSpyTestCase
         $sampleRate = 1.0;
         $tag = 'string:tag';
 
-        $expectedUdpMessage = 'foo.metric:82.00|s|#string:tag';
+        $expectedUdpMessage = 'foo.metric:82|s|#string:tag';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -489,7 +489,7 @@ class SocketsTest extends SocketSpyTestCase
         $sampleRate = 1.0;
         $tag = null;
 
-        $expectedUdpMessage = 'foo.metric:19872.00|h';
+        $expectedUdpMessage = 'foo.metric:19872|h';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -761,7 +761,7 @@ class SocketsTest extends SocketSpyTestCase
             $expectedUdpMessage2,
             $argsPassedToSocketSendto[1][1],
             'Should send the expected message for the first call',
-            array("metrics" => 0, "bytes_sent" => 690, "packets_sent" => 1)
+            array("metrics" => 0, "bytes_sent" => 693, "packets_sent" => 1)
         );
     }
 
@@ -1046,7 +1046,7 @@ class SocketsTest extends SocketSpyTestCase
             count($spy->argsFromSocketSendtoCalls),
             'Should send 1 UDP message'
         );
-        $expectedUdpMessage = 'metric:42.00|ms|#my_tag:tag_value';
+        $expectedUdpMessage = 'metric:42|ms|#my_tag:tag_value';
         $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
 
         $this->assertSameWithTelemetry(
@@ -1145,7 +1145,7 @@ class SocketsTest extends SocketSpyTestCase
         $dog->gauge('metric', 42);
 
         $this->assertSame(
-            'metric:42|g',
+            'metric:42.00|g',
             $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]
         );
     }
@@ -1166,7 +1166,7 @@ class SocketsTest extends SocketSpyTestCase
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
         $dog->timing('test', 21);
-        $this->assertSameWithTelemetry('test:21|ms', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]);
+        $this->assertSameWithTelemetry('test:21.00|ms', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]);
 
         $dog->gauge('test', 21);
         $this->assertSameWithTelemetry('test:21|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 675, "packets_sent" => 1));
@@ -1208,7 +1208,7 @@ class SocketsTest extends SocketSpyTestCase
         $this->getSocketSpy()->returnErrorOnSend = false;
 
         $dog->gauge('test', 22);
-        $this->assertSameWithTelemetry('test:22|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1], "", array("metrics" => 3, "bytes_dropped" => 1351, "packets_dropped" => 2));
+        $this->assertSameWithTelemetry('test:22.00|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1], "", array("metrics" => 3, "bytes_dropped" => 1351, "packets_dropped" => 2));
 
         # force flush to get the telemetry about the last message sent
         $dog->flush("");

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -126,7 +126,7 @@ class SocketsTest extends SocketSpyTestCase
         $time = 43;
         $sampleRate = 1.0;
         $tags = array('horse' => 'cart');
-        $expectedUdpMessage = 'some.timing_metric:43.00|ms|#horse:cart';
+        $expectedUdpMessage = 'some.timing_metric:43|ms|#horse:cart';
 
         $dog = new DogStatsd(array('disable_telemetry' => false));
 
@@ -159,7 +159,7 @@ class SocketsTest extends SocketSpyTestCase
         $time = 26;
         $sampleRate = 1.0;
         $tags = array('tuba' => 'solo');
-        $expectedUdpMessage = 'some.microtiming_metric:26000.00|ms|#tuba:solo';
+        $expectedUdpMessage = 'some.microtiming_metric:26000|ms|#tuba:solo';
 
         $dog = new DogStatsd(array('disable_telemetry' => false));
 
@@ -192,7 +192,7 @@ class SocketsTest extends SocketSpyTestCase
         $value = 5;
         $sampleRate = 1.0;
         $tags = array('baseball' => 'cap');
-        $expectedUdpMessage = 'some.gauge_metric:5.00|g|#baseball:cap';
+        $expectedUdpMessage = 'some.gauge_metric:5|g|#baseball:cap';
 
         $dog = new DogStatsd(array('disable_telemetry' => false));
 
@@ -225,7 +225,7 @@ class SocketsTest extends SocketSpyTestCase
         $value = 109;
         $sampleRate = 1.0;
         $tags = array('happy' => 'days');
-        $expectedUdpMessage = 'some.histogram_metric:109.00|h|#happy:days';
+        $expectedUdpMessage = 'some.histogram_metric:109|h|#happy:days';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -258,7 +258,7 @@ class SocketsTest extends SocketSpyTestCase
         $value = 7;
         $sampleRate = 1.0;
         $tags = array('floppy' => 'hat');
-        $expectedUdpMessage = 'some.distribution_metric:7.00|d|#floppy:hat';
+        $expectedUdpMessage = 'some.distribution_metric:7|d|#floppy:hat';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -291,7 +291,7 @@ class SocketsTest extends SocketSpyTestCase
         $value = 22239;
         $sampleRate = 1.0;
         $tags = array('little' => 'bit');
-        $expectedUdpMessage = 'some.set_metric:22239.00|s|#little:bit';
+        $expectedUdpMessage = 'some.set_metric:22239|s|#little:bit';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -425,8 +425,8 @@ class SocketsTest extends SocketSpyTestCase
             'cowboy' => 'hat'
         );
 
-        $expectedUdpMessage1 = 'foo.metric:893.00|s|#cowboy:hat';
-        $expectedUdpMessage2 = 'bar.metric:4.00|s|#cowboy:hat';
+        $expectedUdpMessage1 = 'foo.metric:893|s|#cowboy:hat';
+        $expectedUdpMessage2 = 'bar.metric:4|s|#cowboy:hat';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -454,7 +454,7 @@ class SocketsTest extends SocketSpyTestCase
             $expectedUdpMessage2,
             $argsPassedToSocketSendtoCall2[1],
             'Second UDP message should be correct',
-            array("bytes_sent" => 696, "packets_sent" => 1)
+            array("bytes_sent" => 693, "packets_sent" => 1)
         );
     }
 
@@ -606,7 +606,7 @@ class SocketsTest extends SocketSpyTestCase
             'foo.metric',
         );
 
-        $expectedUdpMessage = 'foo.metric:1.00|c';
+        $expectedUdpMessage = 'foo.metric:1|c';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -635,7 +635,7 @@ class SocketsTest extends SocketSpyTestCase
             'foo.metric',
         );
 
-        $expectedUdpMessage = 'foo.metric:-1.00|c';
+        $expectedUdpMessage = 'foo.metric:-1|c';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -664,7 +664,7 @@ class SocketsTest extends SocketSpyTestCase
             'foo.metric',
         );
 
-        $expectedUdpMessage = 'foo.metric:-9.00|c';
+        $expectedUdpMessage = 'foo.metric:-9|c';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -693,7 +693,7 @@ class SocketsTest extends SocketSpyTestCase
             'foo.metric',
         );
 
-        $expectedUdpMessage = 'foo.metric:-47.00|c';
+        $expectedUdpMessage = 'foo.metric:-47|c';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -728,8 +728,8 @@ class SocketsTest extends SocketSpyTestCase
             'every' => 'day',
         );
 
-        $expectedUdpMessage1 = 'foo.metric:3.00|c|#every:day';
-        $expectedUdpMessage2 = 'bar.metric:3.00|c|#every:day';
+        $expectedUdpMessage1 = 'foo.metric:3|c|#every:day';
+        $expectedUdpMessage2 = 'bar.metric:3|c|#every:day';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -761,7 +761,7 @@ class SocketsTest extends SocketSpyTestCase
             $expectedUdpMessage2,
             $argsPassedToSocketSendto[1][1],
             'Should send the expected message for the first call',
-            array("metrics" => 0, "bytes_sent" => 693, "packets_sent" => 1)
+            array("metrics" => 0, "bytes_sent" => 690, "packets_sent" => 1)
         );
     }
 
@@ -774,7 +774,7 @@ class SocketsTest extends SocketSpyTestCase
             'long' => 'walk',
         );
 
-        $expectedUdpMessage = 'foo.metric:-45.00|c|#long:walk';
+        $expectedUdpMessage = 'foo.metric:-45|c|#long:walk';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -1046,7 +1046,7 @@ class SocketsTest extends SocketSpyTestCase
             count($spy->argsFromSocketSendtoCalls),
             'Should send 1 UDP message'
         );
-        $expectedUdpMessage = 'metric:42.00|ms|#my_tag:tag_value';
+        $expectedUdpMessage = 'metric:42|ms|#my_tag:tag_value';
         $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
 
         $this->assertSameWithTelemetry(
@@ -1073,7 +1073,7 @@ class SocketsTest extends SocketSpyTestCase
             count($spy->argsFromSocketSendtoCalls),
             'Should send 1 UDP message'
         );
-        $expectedUdpMessage = 'metric:42.00|ms|#my_tag:tag_value,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d';
+        $expectedUdpMessage = 'metric:42|ms|#my_tag:tag_value,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d';
         $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
 
         $this->assertSameWithTelemetry(
@@ -1100,7 +1100,7 @@ class SocketsTest extends SocketSpyTestCase
             count($spy->argsFromSocketSendtoCalls),
             'Should send 1 UDP message'
         );
-        $expectedUdpMessage = 'metric:42.00|ms|#my_tag:tag_value,other_tag:other_value';
+        $expectedUdpMessage = 'metric:42|ms|#my_tag:tag_value,other_tag:other_value';
         $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
 
         $this->assertSameWithTelemetry(
@@ -1128,7 +1128,7 @@ class SocketsTest extends SocketSpyTestCase
             count($spy->argsFromSocketSendtoCalls),
             'Should send 1 UDP message'
         );
-        $expectedUdpMessage = 'metric:42.00|ms|#my_tag:other_value';
+        $expectedUdpMessage = 'metric:42|ms|#my_tag:other_value';
         $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
 
         $this->assertSameWithTelemetry(
@@ -1145,7 +1145,7 @@ class SocketsTest extends SocketSpyTestCase
         $dog->gauge('metric', 42);
 
         $this->assertSame(
-            'metric:42.00|g',
+            'metric:42|g',
             $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]
         );
     }
@@ -1156,7 +1156,7 @@ class SocketsTest extends SocketSpyTestCase
         $dog->gauge('metric', 42);
 
         $this->assertSameWithTelemetry(
-            'metric:42.00|g',
+            'metric:42|g',
             $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]
         );
     }
@@ -1166,28 +1166,28 @@ class SocketsTest extends SocketSpyTestCase
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
         $dog->timing('test', 21);
-        $this->assertSameWithTelemetry('test:21.00|ms', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]);
+        $this->assertSameWithTelemetry('test:21|ms', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]);
 
         $dog->gauge('test', 21);
-        $this->assertSameWithTelemetry('test:21.00|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 678, "packets_sent" => 1));
+        $this->assertSameWithTelemetry('test:21|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 675, "packets_sent" => 1));
 
         $dog->histogram('test', 21);
-        $this->assertSameWithTelemetry('test:21.00|h', $this->getSocketSpy()->argsFromSocketSendtoCalls[2][1], "", array("bytes_sent" => 679, "packets_sent" => 1));
+        $this->assertSameWithTelemetry('test:21|h', $this->getSocketSpy()->argsFromSocketSendtoCalls[2][1], "", array("bytes_sent" => 676, "packets_sent" => 1));
 
         $dog->distribution('test', 21);
-        $this->assertSameWithTelemetry('test:21.00|d', $this->getSocketSpy()->argsFromSocketSendtoCalls[3][1], "", array("bytes_sent" => 679, "packets_sent" => 1));
+        $this->assertSameWithTelemetry('test:21|d', $this->getSocketSpy()->argsFromSocketSendtoCalls[3][1], "", array("bytes_sent" => 676, "packets_sent" => 1));
 
         $dog->set('test', 21);
-        $this->assertSameWithTelemetry('test:21.00|s', $this->getSocketSpy()->argsFromSocketSendtoCalls[4][1], "", array("bytes_sent" => 679, "packets_sent" => 1));
+        $this->assertSameWithTelemetry('test:21|s', $this->getSocketSpy()->argsFromSocketSendtoCalls[4][1], "", array("bytes_sent" => 676, "packets_sent" => 1));
 
         $dog->increment('test');
-        $this->assertSameWithTelemetry('test:1.00|c', $this->getSocketSpy()->argsFromSocketSendtoCalls[5][1], "", array("bytes_sent" => 679, "packets_sent" => 1));
+        $this->assertSameWithTelemetry('test:1|c', $this->getSocketSpy()->argsFromSocketSendtoCalls[5][1], "", array("bytes_sent" => 676, "packets_sent" => 1));
 
         $dog->decrement('test');
-        $this->assertSameWithTelemetry('test:-1.00|c', $this->getSocketSpy()->argsFromSocketSendtoCalls[6][1], "", array("bytes_sent" => 678, "packets_sent" => 1));
+        $this->assertSameWithTelemetry('test:-1|c', $this->getSocketSpy()->argsFromSocketSendtoCalls[6][1], "", array("bytes_sent" => 675, "packets_sent" => 1));
 
         $dog->event('ev', array('text' => 'text'));
-        $this->assertSameWithTelemetry('_e{2,4}:ev|text', $this->getSocketSpy()->argsFromSocketSendtoCalls[7][1], "", array("bytes_sent" => 679, "packets_sent" => 1, "metrics" => 0, "events" => 1));
+        $this->assertSameWithTelemetry('_e{2,4}:ev|text', $this->getSocketSpy()->argsFromSocketSendtoCalls[7][1], "", array("bytes_sent" => 676, "packets_sent" => 1, "metrics" => 0, "events" => 1));
 
         $dog->service_check('sc', 0);
         $this->assertSameWithTelemetry('_sc|sc|0', $this->getSocketSpy()->argsFromSocketSendtoCalls[8][1], "", array("bytes_sent" => 682, "packets_sent" => 1, "metrics" => 0, "service_checks" => 1));
@@ -1208,22 +1208,22 @@ class SocketsTest extends SocketSpyTestCase
         $this->getSocketSpy()->returnErrorOnSend = false;
 
         $dog->gauge('test', 22);
-        $this->assertSameWithTelemetry('test:22.00|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1], "", array("metrics" => 3, "bytes_dropped" => 1357, "packets_dropped" => 2));
+        $this->assertSameWithTelemetry('test:22|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1], "", array("metrics" => 3, "bytes_dropped" => 1351, "packets_dropped" => 2));
 
         # force flush to get the telemetry about the last message sent
         $dog->flush("");
-        $this->assertSameWithTelemetry('', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 680, "packets_sent" => 1, "metrics" => 0));
+        $this->assertSameWithTelemetry('', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 677, "packets_sent" => 1, "metrics" => 0));
     }
 
     public function testDecimalPrecision()
     {
         $dog = new DogStatsd(array("disable_telemetry" => false, "decimal_precision" => 5));
 
-        $dog->timing('test', 21);
-        $this->assertSameWithTelemetry('test:21.00000|ms', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]);
+        $dog->timing('test', 21.00000);
+        $this->assertSameWithTelemetry('test:21|ms', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]);
 
         $dog->gauge('test', 21.222225);
-        $this->assertSameWithTelemetry('test:21.22223|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 681, "packets_sent" => 1));
+        $this->assertSameWithTelemetry('test:21.22223|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 675, "packets_sent" => 1));
     }
 
     public function testFloatLocalization()
@@ -1232,10 +1232,11 @@ class SocketsTest extends SocketSpyTestCase
         setlocale(LC_ALL, 'nl_NL');
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
-        $dog->timing('test', 21.21);
+        $dog->timing('test', 21.21000);
         $this->assertSameWithTelemetry('test:21.21|ms', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]);
         setlocale(LC_ALL, $defaultLocale);
-    }
+      }
+
 
     /**
      * Get a timestamp created from a real date that is deterministic in nature

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -1215,6 +1215,28 @@ class SocketsTest extends SocketSpyTestCase
         $this->assertSameWithTelemetry('', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 680, "packets_sent" => 1, "metrics" => 0));
     }
 
+    public function testDecimalPrecision()
+    {
+        $dog = new DogStatsd(array("disable_telemetry" => false, "decimal_precision" => 5));
+
+        $dog->timing('test', 21);
+        $this->assertSameWithTelemetry('test:21.00000|ms', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]);
+
+        $dog->gauge('test', 21.222225);
+        $this->assertSameWithTelemetry('test:21.22223|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 681, "packets_sent" => 1));
+    }
+
+    public function testFloatLocalization()
+    {
+        $defaultLocale = setlocale(LC_ALL, 0);
+        setlocale(LC_ALL, 'nl_NL');
+        $dog = new DogStatsd(array("disable_telemetry" => false));
+
+        $dog->timing('test', 21.21);
+        $this->assertSameWithTelemetry('test:21.21|ms', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]);
+        setlocale(LC_ALL, $defaultLocale);
+    }
+
     /**
      * Get a timestamp created from a real date that is deterministic in nature
      *

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -1215,7 +1215,7 @@ class SocketsTest extends SocketSpyTestCase
         $this->assertSameWithTelemetry('', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 677, "packets_sent" => 1, "metrics" => 0));
     }
 
-    public function testDecimalPrecision()
+    public function testDecimalNormalization()
     {
         $dog = new DogStatsd(array("disable_telemetry" => false, "decimal_precision" => 5));
 
@@ -1224,6 +1224,9 @@ class SocketsTest extends SocketSpyTestCase
 
         $dog->gauge('test', 21.222225);
         $this->assertSameWithTelemetry('test:21.22223|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 675, "packets_sent" => 1));
+
+        $dog->gauge('test', 2000.00);
+        $this->assertSameWithTelemetry('test:2000|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[2][1], "", array("bytes_sent" => 682, "packets_sent" => 1));
     }
 
     public function testFloatLocalization()
@@ -1235,7 +1238,7 @@ class SocketsTest extends SocketSpyTestCase
         $dog->timing('test', 21.21000);
         $this->assertSameWithTelemetry('test:21.21|ms', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]);
         setlocale(LC_ALL, $defaultLocale);
-      }
+    }
 
 
     /**

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -1057,6 +1057,34 @@ class SocketsTest extends SocketSpyTestCase
         );
     }
 
+    public function testGlobalTagsWithEntityIdFromEnvVar()
+    {
+        putenv("DD_ENTITY_ID=04652bb7-19b7-11e9-9cc6-42010a9c016d");
+        $dog = new DogStatsd(array(
+            'global_tags' => array(
+                'my_tag' => 'tag_value',
+            ),
+            'disable_telemetry' => false
+        ));
+        $dog->timing('metric', 42, 1.0);
+        $spy = $this->getSocketSpy();
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+        $expectedUdpMessage = 'metric:42.00|ms|#my_tag:tag_value,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d';
+        $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSameWithTelemetry(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendTo[1],
+            "",
+            array("tags" => "my_tag:tag_value,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d")
+        );
+        putenv("DD_ENTITY_ID");
+    }
+
     public function testGlobalTagsAreSupplementedWithLocalTags()
     {
         $dog = new DogStatsd(array(
@@ -1159,7 +1187,7 @@ class SocketsTest extends SocketSpyTestCase
         $this->assertSameWithTelemetry('test:-1.00|c', $this->getSocketSpy()->argsFromSocketSendtoCalls[6][1], "", array("bytes_sent" => 678, "packets_sent" => 1));
 
         $dog->event('ev', array('text' => 'text'));
-        $this->assertSameWithTelemetry('_e{2,4}:ev|text', $this->getSocketSpy()->argsFromSocketSendtoCalls[7][1], "", array("bytes_sent" => 676, "packets_sent" => 1, "metrics" => 0, "events" => 1));
+        $this->assertSameWithTelemetry('_e{2,4}:ev|text', $this->getSocketSpy()->argsFromSocketSendtoCalls[7][1], "", array("bytes_sent" => 679, "packets_sent" => 1, "metrics" => 0, "events" => 1));
 
         $dog->service_check('sc', 0);
         $this->assertSameWithTelemetry('_sc|sc|0', $this->getSocketSpy()->argsFromSocketSendtoCalls[8][1], "", array("bytes_sent" => 682, "packets_sent" => 1, "metrics" => 0, "service_checks" => 1));
@@ -1184,35 +1212,7 @@ class SocketsTest extends SocketSpyTestCase
 
         # force flush to get the telemetry about the last message sent
         $dog->flush("");
-        $this->assertSameWithTelemetry('', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 677, "packets_sent" => 1, "metrics" => 0));
-    }
-
-    public function testGlobalTagsWithEntityIdFromEnvVar()
-    {
-        putenv("DD_ENTITY_ID=04652bb7-19b7-11e9-9cc6-42010a9c016d");
-        $dog = new DogStatsd(array(
-            'global_tags' => array(
-                'my_tag' => 'tag_value',
-            ),
-            'disable_telemetry' => false
-        ));
-        $dog->timing('metric', 42, 1.0);
-        $spy = $this->getSocketSpy();
-        $this->assertSame(
-            1,
-            count($spy->argsFromSocketSendtoCalls),
-            'Should send 1 UDP message'
-        );
-        $expectedUdpMessage = 'metric:42.00|ms|#my_tag:tag_value,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d';
-        $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
-
-        $this->assertSameWithTelemetry(
-            $expectedUdpMessage,
-            $argsPassedToSocketSendTo[1],
-            "",
-            array("tags" => "my_tag:tag_value,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d")
-        );
-        putenv("DD_ENTITY_ID");
+        $this->assertSameWithTelemetry('', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 680, "packets_sent" => 1, "metrics" => 0));
     }
 
     /**

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -126,7 +126,7 @@ class SocketsTest extends SocketSpyTestCase
         $time = 43;
         $sampleRate = 1.0;
         $tags = array('horse' => 'cart');
-        $expectedUdpMessage = 'some.timing_metric:43|ms|#horse:cart';
+        $expectedUdpMessage = 'some.timing_metric:43.00|ms|#horse:cart';
 
         $dog = new DogStatsd(array('disable_telemetry' => false));
 
@@ -159,7 +159,7 @@ class SocketsTest extends SocketSpyTestCase
         $time = 26;
         $sampleRate = 1.0;
         $tags = array('tuba' => 'solo');
-        $expectedUdpMessage = 'some.microtiming_metric:26000|ms|#tuba:solo';
+        $expectedUdpMessage = 'some.microtiming_metric:26000.00|ms|#tuba:solo';
 
         $dog = new DogStatsd(array('disable_telemetry' => false));
 
@@ -192,7 +192,7 @@ class SocketsTest extends SocketSpyTestCase
         $value = 5;
         $sampleRate = 1.0;
         $tags = array('baseball' => 'cap');
-        $expectedUdpMessage = 'some.gauge_metric:5|g|#baseball:cap';
+        $expectedUdpMessage = 'some.gauge_metric:5.00|g|#baseball:cap';
 
         $dog = new DogStatsd(array('disable_telemetry' => false));
 
@@ -225,7 +225,7 @@ class SocketsTest extends SocketSpyTestCase
         $value = 109;
         $sampleRate = 1.0;
         $tags = array('happy' => 'days');
-        $expectedUdpMessage = 'some.histogram_metric:109|h|#happy:days';
+        $expectedUdpMessage = 'some.histogram_metric:109.00|h|#happy:days';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -258,7 +258,7 @@ class SocketsTest extends SocketSpyTestCase
         $value = 7;
         $sampleRate = 1.0;
         $tags = array('floppy' => 'hat');
-        $expectedUdpMessage = 'some.distribution_metric:7|d|#floppy:hat';
+        $expectedUdpMessage = 'some.distribution_metric:7.00|d|#floppy:hat';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -291,7 +291,7 @@ class SocketsTest extends SocketSpyTestCase
         $value = 22239;
         $sampleRate = 1.0;
         $tags = array('little' => 'bit');
-        $expectedUdpMessage = 'some.set_metric:22239|s|#little:bit';
+        $expectedUdpMessage = 'some.set_metric:22239.00|s|#little:bit';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -425,8 +425,8 @@ class SocketsTest extends SocketSpyTestCase
             'cowboy' => 'hat'
         );
 
-        $expectedUdpMessage1 = 'foo.metric:893|s|#cowboy:hat';
-        $expectedUdpMessage2 = 'bar.metric:4|s|#cowboy:hat';
+        $expectedUdpMessage1 = 'foo.metric:893.00|s|#cowboy:hat';
+        $expectedUdpMessage2 = 'bar.metric:4.00|s|#cowboy:hat';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -466,7 +466,7 @@ class SocketsTest extends SocketSpyTestCase
         $sampleRate = 1.0;
         $tag = 'string:tag';
 
-        $expectedUdpMessage = 'foo.metric:82|s|#string:tag';
+        $expectedUdpMessage = 'foo.metric:82.00|s|#string:tag';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -489,7 +489,7 @@ class SocketsTest extends SocketSpyTestCase
         $sampleRate = 1.0;
         $tag = null;
 
-        $expectedUdpMessage = 'foo.metric:19872|h';
+        $expectedUdpMessage = 'foo.metric:19872.00|h';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -606,7 +606,7 @@ class SocketsTest extends SocketSpyTestCase
             'foo.metric',
         );
 
-        $expectedUdpMessage = 'foo.metric:1|c';
+        $expectedUdpMessage = 'foo.metric:1.00|c';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -664,7 +664,7 @@ class SocketsTest extends SocketSpyTestCase
             'foo.metric',
         );
 
-        $expectedUdpMessage = 'foo.metric:-9|c';
+        $expectedUdpMessage = 'foo.metric:-9.00|c';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -693,7 +693,7 @@ class SocketsTest extends SocketSpyTestCase
             'foo.metric',
         );
 
-        $expectedUdpMessage = 'foo.metric:-47|c';
+        $expectedUdpMessage = 'foo.metric:-47.00|c';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -728,8 +728,8 @@ class SocketsTest extends SocketSpyTestCase
             'every' => 'day',
         );
 
-        $expectedUdpMessage1 = 'foo.metric:3|c|#every:day';
-        $expectedUdpMessage2 = 'bar.metric:3|c|#every:day';
+        $expectedUdpMessage1 = 'foo.metric:3.00|c|#every:day';
+        $expectedUdpMessage2 = 'bar.metric:3.00|c|#every:day';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -774,7 +774,7 @@ class SocketsTest extends SocketSpyTestCase
             'long' => 'walk',
         );
 
-        $expectedUdpMessage = 'foo.metric:-45|c|#long:walk';
+        $expectedUdpMessage = 'foo.metric:-45.00|c|#long:walk';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -1046,7 +1046,7 @@ class SocketsTest extends SocketSpyTestCase
             count($spy->argsFromSocketSendtoCalls),
             'Should send 1 UDP message'
         );
-        $expectedUdpMessage = 'metric:42|ms|#my_tag:tag_value';
+        $expectedUdpMessage = 'metric:42.00|ms|#my_tag:tag_value';
         $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
 
         $this->assertSameWithTelemetry(
@@ -1100,7 +1100,7 @@ class SocketsTest extends SocketSpyTestCase
             count($spy->argsFromSocketSendtoCalls),
             'Should send 1 UDP message'
         );
-        $expectedUdpMessage = 'metric:42|ms|#my_tag:tag_value,other_tag:other_value';
+        $expectedUdpMessage = 'metric:42.00|ms|#my_tag:tag_value,other_tag:other_value';
         $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
 
         $this->assertSameWithTelemetry(
@@ -1128,7 +1128,7 @@ class SocketsTest extends SocketSpyTestCase
             count($spy->argsFromSocketSendtoCalls),
             'Should send 1 UDP message'
         );
-        $expectedUdpMessage = 'metric:42|ms|#my_tag:other_value';
+        $expectedUdpMessage = 'metric:42.00|ms|#my_tag:other_value';
         $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
 
         $this->assertSameWithTelemetry(

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -635,7 +635,7 @@ class SocketsTest extends SocketSpyTestCase
             'foo.metric',
         );
 
-        $expectedUdpMessage = 'foo.metric:-1|c';
+        $expectedUdpMessage = 'foo.metric:-1.00|c';
 
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
@@ -1046,7 +1046,7 @@ class SocketsTest extends SocketSpyTestCase
             count($spy->argsFromSocketSendtoCalls),
             'Should send 1 UDP message'
         );
-        $expectedUdpMessage = 'metric:42|ms|#my_tag:tag_value';
+        $expectedUdpMessage = 'metric:42.00|ms|#my_tag:tag_value';
         $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
 
         $this->assertSameWithTelemetry(
@@ -1073,7 +1073,7 @@ class SocketsTest extends SocketSpyTestCase
             count($spy->argsFromSocketSendtoCalls),
             'Should send 1 UDP message'
         );
-        $expectedUdpMessage = 'metric:42|ms|#my_tag:tag_value,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d';
+        $expectedUdpMessage = 'metric:42.00|ms|#my_tag:tag_value,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d';
         $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
 
         $this->assertSameWithTelemetry(
@@ -1082,7 +1082,7 @@ class SocketsTest extends SocketSpyTestCase
             "",
             array("tags" => "my_tag:tag_value,dd.internal.entity_id:04652bb7-19b7-11e9-9cc6-42010a9c016d")
         );
-        putenv("DD_ENTITY_ID");
+        putenv("DD_ENTITY_ID=''");
     }
 
     public function testGlobalTagsAreSupplementedWithLocalTags()


### PR DESCRIPTION
Stat values are converted to a string as part of building the statsd protocol string and creating the UDP payload. Coercion from float to string folows locale formats, which for some countries uses comma instead of period for floats.

E.x. 
```
echo 'US locale' . PHP_EOL;
$client->increment('test', 1, 'tag', 1000.001);
$client->increment('test', 1, 'tag', 1000.001);
$client->decrement('test', 1, 'tag', 1000.001);
// Set 
setlocale(LC_ALL, 'nl_NL');

echo 'Dutch locale' . PHP_EOL;
$client->increment('test', 1, 'tag', 1000.001);
$client->increment('test', 1, 'tag', 1000.001);
$client->decrement('test', 1, 'tag', 1000.001);
```
yields
```
US locale
Preformat:  1000.001
Postformat:  1000.00100
Preformat:  1000.001
Postformat:  1000.00100
Preformat:  -1000.001
Postformat:  -1000.00100
Dutch locale
Preformat:  1000,001
Postformat:  1000.00100
Preformat:  1000,001
Postformat:  1000.00100
Preformat:  -1000,001
Postformat:  -1000.00100
```
before and after using `number_format` when changing to a string.