### PR TITLE
Support PHP 8.0 and drop PHP 5.6, 7.0, 7.1 and 7.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,5 @@
 .idea
 /vendor/
 /composer.lock
-
+.phpunit.result.cache
 *.swp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
-  - 7.1
-  - 7.2
+  - 7.3
+  - 7.4
+  - 8.0
+  - nightly
 
 cache:
   directories:
@@ -20,5 +20,5 @@ script:
 
   # Execute PHPUnit tests
   - composer install --prefer-dist
-  - vendor/bin/phpunit --coverage-text
+  - XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-text
   - composer lint

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This is an extremely simple PHP [DogStatsD](https://docs.datadoghq.com/developers/dogstatsd/?tab=php) client.
 
-**Requires PHP >= 5.6.0.**
+**Requires PHP >= 7.3.0.**
 
 See [CHANGELOG.md](CHANGELOG.md) for changes.
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.3.0",
         "ext-curl": "*",
         "lib-curl": "*",
         "ext-sockets": "*"
@@ -49,7 +49,7 @@
         "sort-packages": true
     },
     "require-dev": {
-        "phpunit/phpunit": "5.7.27",
+        "phpunit/phpunit": "8.5.15",
         "squizlabs/php_codesniffer": "^3.3"
     },
     "scripts": {

--- a/tests/TestHelpers/CurlSpyTestCase.php
+++ b/tests/TestHelpers/CurlSpyTestCase.php
@@ -11,7 +11,7 @@ class CurlSpyTestCase extends TestCase
     /**
      * Set up a spy object to capture calls to built in curl functions
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         global $curlSpy;
 

--- a/tests/TestHelpers/SocketSpyTestCase.php
+++ b/tests/TestHelpers/SocketSpyTestCase.php
@@ -24,7 +24,7 @@ class SocketSpyTestCase extends TestCase
     /**
      * Set up a spy object to capture calls to global built in socket functions
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         global $socketSpy;
 

--- a/tests/UnitTests/BatchedDogStatsdTest.php
+++ b/tests/UnitTests/BatchedDogStatsdTest.php
@@ -8,7 +8,7 @@ use DataDog\TestHelpers\SocketSpyTestCase;
 
 class BatchedDogStatsdTest extends SocketSpyTestCase
 {
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -9,7 +9,7 @@ use DataDog\TestHelpers\SocketSpyTestCase;
 
 class SocketsTest extends SocketSpyTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Support PHP 8.0 but drop PHP 5.6, 7.0, 7.1 and 7.2 because PHPUnit 8.x does not support them