### PR TITLE
Feature/injectable transport

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2 # use CircleCI 2.0
 
-x-dockerbuild-7: &dockerbuild-7
+x-dockerbuild-phpdbg: &dockerbuild-phpdbg
   steps:
     - checkout
     - run: sudo docker-php-ext-install sockets
@@ -19,16 +19,28 @@ x-dockerbuild-5: &dockerbuild-5
     - run: composer lint
 
 jobs:
+  test-8.0:
+    <<: *dockerbuild-phpdbg
+    docker:
+      - image: circleci/php:8.0-node-browsers
+  test-7.4:
+    <<: *dockerbuild-phpdbg
+    docker:
+      - image: circleci/php:7.4-node-browsers
+  test-7.3:
+    <<: *dockerbuild-phpdbg
+    docker:
+      - image: circleci/php:7.3-node-browsers
   test-7.2:
-    <<: *dockerbuild-7
+    <<: *dockerbuild-phpdbg
     docker:
       - image: circleci/php:7.2-node-browsers
   test-7.1:
-    <<: *dockerbuild-7
+    <<: *dockerbuild-phpdbg
     docker:
       - image: circleci/php:7.1-node-browsers
   test-7.0:
-    <<: *dockerbuild-7
+    <<: *dockerbuild-phpdbg
     docker:
       - image: circleci/php:7.0-node-browsers
   test-5.6:
@@ -40,6 +52,9 @@ workflows:
   version: 2
   check_compile:
     jobs:
+      - test-8.0
+      - test-7.4
+      - test-7.3
       - test-7.2
       - test-7.1
       - test-7.0

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.php text eol=lf

--- a/README.md
+++ b/README.md
@@ -46,6 +46,64 @@ $statsd = new DogStatsd(
 
 DogStatsd constructor, takes a configuration array. See the full list of available [DogStatsD Client instantiation parameters](https://docs.datadoghq.com/developers/dogstatsd/?code-lang=php#client-instantiation-parameters).
 
+#### Migrating from legacy configuration
+
+In some setups, the use of environment variables can cause surprises, such as warnings, test-failures, etc.
+
+There is a new argument `transport_factory`, which takes an argument that _implements_ `DataDog\TransportFactory` interface. This has one method `create`, which can return, one or more classes implementing `DataDog\TransportMechanism`. This can be particularly useful if you experience warnings, errors or other output from the PHP built-in's this library uses for communicating stats.
+
+##### Defining custom implementation of transport factory
+
+```php
+<?php
+
+namespace YourOrg\Metrics;
+
+/**
+ * This class works around the decisions the constructor of DogStatsd class
+ * Which has default convenience functionality, which can make your code
+ * more difficult to reason about.
+ */
+final class CustomTransportFactory implements DataDog\TransportFactory
+{
+    private $host;
+    private $port;
+
+    public function __construct($host, $port)
+    {
+        if (empty($host) || empty($port)) {
+            throw new \ArgumentException("Must specify host and port");
+        }
+    }
+
+    public function create()
+    {
+        return new Ipv4UdpTransport(
+            $this->host,
+            $this->port
+        );
+    }
+}
+```
+
+##### Instantiating datadog with your new class
+```php
+<?php
+
+require __DIR__ . '/vendor/autoload.php';
+
+use DataDog\DogStatsd;
+use YourOrg\Metrics\CustomTransportFactory;
+
+$statsd = new DogStatsd(
+    array('transport_factory' =>, new CustomTransportFactory())
+);
+```
+
+#### Why this structure?
+
+The reason a factory is used to create an instance, is that DogStatsD opens sockets on the machine running this code. If sockets are left open and unclosed, then the second time a socket is to be created, more problems arise.
+
 ### Origin detection over UDP in Kubernetes
 
 Origin detection is a method to detect which pod DogStatsD packets are coming from in order to add the pod's tags to the tag list.

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "sort-packages": true
     },
     "require-dev": {
-        "phpunit/phpunit": "5.7.27",
+        "yoast/phpunit-polyfills": "^1.0.1",
         "squizlabs/php_codesniffer": "^3.3"
     },
     "scripts": {

--- a/src/BatchedDogStatsd.php
+++ b/src/BatchedDogStatsd.php
@@ -19,13 +19,13 @@ class BatchedDogStatsd extends DogStatsd
     public static $maxBufferLength = 50;
 
 
-    public function __construct(array $config = array())
+    public function __construct(array $config = array(), $transportFactory = null)
     {
         // by default the telemetry is enabled for BatchedDogStatsd
         if (!isset($config["disable_telemetry"])) {
             $config["disable_telemetry"] = false;
         }
-        parent::__construct($config);
+        parent::__construct($config, $transportFactory);
     }
 
     /**

--- a/src/BridgingTransportFactory.php
+++ b/src/BridgingTransportFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DataDog;
+
+final class BridgingTransportFactory implements TransportFactory
+{
+    private $socketPath;
+    private $host;
+    private $port;
+
+    public function __construct($socketPath = null, $host = null, $port = null)
+    {
+        $this->socketPath = $socketPath;
+        $this->host = $host;
+        $this->port = $port;
+    }
+
+    /**
+     * @return TransportMechanism
+    */
+    public function create()
+    {
+        if (is_null($this->socketPath)) {
+            return new Ipv4UdpTransport(
+                $this->host,
+                $this->port
+            );
+        }
+
+        return new UnixSocketTransport($this->socketPath);
+    }
+}

--- a/src/Ipv4UdpTransport.php
+++ b/src/Ipv4UdpTransport.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace DataDog;
+
+final class Ipv4UdpTransport implements TransportMechanism
+{
+    private $host;
+    private $port;
+    private $socket;
+
+    public function __construct($host, $port)
+    {
+        $this->host = $host;
+        $this->port = $port;
+        $this->socket = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
+        socket_set_nonblock($this->socket);
+    }
+
+    public function sendMessage($message)
+    {
+        return (bool) socket_sendto($this->socket, $message, strlen($message), 0, $this->host, $this->port);
+    }
+
+    public function __destruct()
+    {
+        socket_close($this->socket);
+    }
+}

--- a/src/TransportFactory.php
+++ b/src/TransportFactory.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DataDog;
+
+/**
+ * Contract for creating an instance of TransportMechanism.
+ * For Runtime creation of implementations of the TransportMechanism contract.
+ * Used for statsd. Can be used to re-factor constructor logic.
+ */
+interface TransportFactory
+{
+    /**
+     * @return TransportMechanism
+     */
+    public function create();
+}

--- a/src/TransportMechanism.php
+++ b/src/TransportMechanism.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace DataDog;
+
+/**
+ * Contract for all-transports of DataDog statsd flush.
+ * Can be used to for test-doubles, fallback implementations; future iterations.
+ */
+interface TransportMechanism
+{
+    /**
+     * @return bool
+     */
+    public function sendMessage($message);
+}

--- a/src/UnixSocketTransport.php
+++ b/src/UnixSocketTransport.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DataDog;
+
+final class UnixSocketTransport implements TransportMechanism
+{
+    private $socket;
+    private $socketPath;
+
+    public function __construct($socketPath)
+    {
+        $this->socket = socket_create(AF_UNIX, SOCK_DGRAM, 0);
+        socket_set_nonblock($this->socket);
+        $this->socketPath = $socketPath;
+    }
+
+    public function sendMessage($message)
+    {
+        return (bool) socket_sendto($this->socket, $message, strlen($message), 0, $this->socketPath);
+    }
+
+    public function __destruct()
+    {
+        socket_close($this->socket);
+    }
+}

--- a/tests/TestHelpers/CurlSpyTestCase.php
+++ b/tests/TestHelpers/CurlSpyTestCase.php
@@ -2,7 +2,7 @@
 
 namespace DataDog\TestHelpers;
 
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 $curlSpy = new CurlSpy();
 
@@ -11,13 +11,12 @@ class CurlSpyTestCase extends TestCase
     /**
      * Set up a spy object to capture calls to built in curl functions
      */
-    protected function setUp()
+    protected function set_up()
     {
         global $curlSpy;
 
         $curlSpy = new CurlSpy();
-
-        parent::setUp();
+        parent::set_up();
     }
 
     /**

--- a/tests/TestHelpers/SocketSpyTestCase.php
+++ b/tests/TestHelpers/SocketSpyTestCase.php
@@ -3,7 +3,7 @@
 namespace DataDog\TestHelpers;
 
 use DataDog\DogStatsd;
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Making this variable global to this file is necessary for interacting with
@@ -24,13 +24,13 @@ class SocketSpyTestCase extends TestCase
     /**
      * Set up a spy object to capture calls to global built in socket functions
      */
-    protected function setUp()
+    protected function set_up()
     {
         global $socketSpy;
 
         $socketSpy = new SocketSpy();
 
-        parent::setUp();
+        parent::set_up();
     }
 
     /**

--- a/tests/UnitTests/BatchedDogStatsdTest.php
+++ b/tests/UnitTests/BatchedDogStatsdTest.php
@@ -8,9 +8,9 @@ use DataDog\TestHelpers\SocketSpyTestCase;
 
 class BatchedDogStatsdTest extends SocketSpyTestCase
 {
-    protected function setUp()
+    protected function set_up()
     {
-        parent::setUp();
+        parent::set_up();
 
         // Flush the buffer to reset state for next test
         BatchedDogStatsd::$maxBufferLength = 50;

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -9,9 +9,9 @@ use DataDog\TestHelpers\SocketSpyTestCase;
 
 class SocketsTest extends SocketSpyTestCase
 {
-    public function setUp()
+    public function set_up()
     {
-        parent::setUp();
+        parent::set_up();
 
         // Reset the stubs for mt_rand() and mt_getrandmax()
         global $mt_rand_stub_return_value;

--- a/tests/curl_and_error_log_function_stubs.php
+++ b/tests/curl_and_error_log_function_stubs.php
@@ -24,7 +24,7 @@ function curl_init($url = null)
 
     $curlSpy->curlInitWasCalledWithArg($url);
 
-    $resource = fopen('/dev/null', 'r');
+    $resource = tmpfile();
 
     $curlSpy->curlInitDidReturn($resource);
 

--- a/tests/socket_function_stubs.php
+++ b/tests/socket_function_stubs.php
@@ -29,7 +29,7 @@ function socket_create($domain, $type, $protocol)
 
     // A PHP resource of unimportance, useful primarily to assert that our stubs
     // of the global socket functions return or take a deterministic value.
-    $resource = fopen('/dev/null', 'r');
+    $resource = tmpfile();
 
     $socketSpy->socketCreateDidReturn($resource);
 


### PR DESCRIPTION
Fixes #115

* Proposed code changes (minimal, interface based)
* Test fix (I was authoring on Windows, and it was a pain, I could not run tests. It's 2-liner)
* ~GitHub actions (until I'd fixed, I actually had a really slow feedback loop)~
* Editor config and git attributes
* Proposed Documentation (words are hard, forgive me if it's not perfect).
* Update to support PHP 8.0 & 8.1 thanks to Yoast
* Tests
* PHP 5.6 - PHP 8.1 (circleci missing 8.1-node-browsers image 🤷 )
* Linting, Code-Style

The actual guard portion of this, doesn't have to be owned by this repo. In the README.md I added a section with example to bypass the magic, re-using the Ipv4Udp transport that is part of this PR, so that an example of instrumenting the control I was looking for (bypassing the magic in current constructor) is available.

I'm not 💯 sure about the construct with single method interface, but felt that opening and closing the socket separately to the functionality; could make some future testing easier. I Also didn't want to open a long-lived socket (although the classes don't hint at that, the way they are used in one place enforces for-now).

The interfaces are pretty stripped-back to deal with PHP 5.6 minimum. Not sure where DataDog is going with that, but I think users would get a lot of benefit rolling up to only 7.4 & 8+ in a future release.

### Why interfaces
Short answer. I Hate the array approach. It's too open a design, and leads to choices where spooky [mis]configuration can happen. While this one interface won't change the entire codebase, it nudges in a direction a lot of PHP coders are going.

I'm not sure that adding `strict_mode` to counteract the magic will make this code any more readable or be the right way to counteract the magic cascade. For an upstream vendor to us this, implement the interface, I believe is a far more intentional choice, that leaves the majority of users happy where they are now. Internal `getenv` may be a feature for people who have not had silent misconfiguration lead to confusing bugs.

Another reason for an interface based approach is that I think a test implementation that allows spy test-double would be a nice thing that this allows. Instead of using curl spy test class and the socket spy test class, which are namespace coordination dependent.

Lastly, This interface approach would enable any coder:

* To perform unit or integration level tests without needing to setup DataDog agent at all.
* Could also help if falling-back in cases where perhaps the transport might use a PSR Logger, and send using Datadog API key as a log message.