### PR TITLE
Adding suppport for a metric prefix

### DIFF
--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -60,6 +60,10 @@ class DogStatsd
      * @var int Number of decimals to use when formatting numbers to strings
      */
     private $decimalPrecision;
+    /**
+     * @var string The prefix to apply to all metrics
+     */
+    private $metricPrefix;
 
     private static $eventUrl = '/api/v1/events';
 
@@ -74,7 +78,9 @@ class DogStatsd
      * curl_ssl_verify_host,
      * curl_ssl_verify_peer,
      * api_key and app_key,
-     * decimal_precision
+     * global_tags,
+     * decimal_precision,
+     * metric_prefix
      *
      * @param array $config
      */
@@ -103,6 +109,8 @@ class DogStatsd
         if (getenv('DD_ENTITY_ID')) {
             $this->globalTags['dd.internal.entity_id'] = getenv('DD_ENTITY_ID');
         }
+
+        $this->metricPrefix = isset($config['metric_prefix']) ? "$config[metric_prefix]." : '';
 
         if ($this->apiKey !== null) {
             $this->submitEventsOver = 'TCP';
@@ -387,7 +395,7 @@ class DogStatsd
 
         foreach ($sampledData as $stat => $value) {
             $value .= $this->serializeTags($tags);
-            $this->report("$stat:$value");
+            $this->report("{$this->metricPrefix}$stat:$value");
         }
     }
 

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -1273,6 +1273,20 @@ class SocketsTest extends SocketSpyTestCase
         setlocale(LC_ALL, $defaultLocale);
     }
 
+    public function testMetricPrefix()
+    {
+      $dog = new DogStatsd(array("disable_telemetry" => false, "metric_prefix" => 'test_prefix'));
+
+      $dog->timing('test', 21.00);
+      $this->assertSameWithTelemetry('test_prefix.test:21|ms', $this->getSocketSpy()->argsFromSocketSendtoCalls[0][1]);
+
+      $dog->gauge('test', 21.22);
+      $this->assertSameWithTelemetry('test_prefix.test:21.22|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[1][1], "", array("bytes_sent" => 687, "packets_sent" => 1));
+
+      $dog->gauge('test', 2000.00);
+      $this->assertSameWithTelemetry('test_prefix.test:2000|g', $this->getSocketSpy()->argsFromSocketSendtoCalls[2][1], "", array("bytes_sent" => 691, "packets_sent" => 1));
+    }
+
 
     /**
      * Get a timestamp created from a real date that is deterministic in nature


### PR DESCRIPTION
Adding support for enabling a default metric prefix similar to other dogstatsd libraries.