### PR TITLE
Fix boolean tag values

### DIFF
--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -323,6 +323,8 @@ class DogStatsd
         foreach ($all_tags as $tag => $value) {
             if ($value === null) {
                 $tag_strings[] = $tag;
+            } elseif (is_bool($value)) {
+                $tag_strings[] = $tag . ':' . ($value === true ? 'true' : 'false');
             } else {
                 $tag_strings[] = $tag . ':' . $value;
             }

--- a/tests/UnitTests/DogStatsd/TagSerializationTest.php
+++ b/tests/UnitTests/DogStatsd/TagSerializationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace DataDog\UnitTests\DogStatsd;
+
+use PHPUnit\Framework\TestCase;
+use DataDog\DogStatsd;
+
+class TagSerializationTest extends TestCase
+{
+    private function callPrivate($object, $method, $params) {
+      $reflectionMethod = new \ReflectionMethod(get_class($object), $method);
+      $reflectionMethod->setAccessible(true);
+      return $reflectionMethod->invoke($object, $params);
+    }
+
+  /**
+   * @dataProvider tagProvider
+   *
+   * @param $tags
+   * @param $expected
+   */
+    public function testTagSerialization($tags, $expected) {
+      $dog = new DogStatsd();
+
+      $this->assertsame(
+          $expected,
+          $this->callPrivate($dog, 'serializeTags', $tags)
+      );
+    }
+
+    public function tagProvider()
+    {
+        return [
+            'without tags' => [
+                [],
+                ''
+            ],
+            'one string' => [
+                ['foo' => 'bar'],
+                '|#foo:bar'
+            ],
+            'two strings' => [
+                ['foo' => 'bar', 'baz' => 'blam'],
+                '|#foo:bar,baz:blam'
+            ],
+            'one string one int' => [
+                ['foo' => 'bar', 'baz' => 42],
+                '|#foo:bar,baz:42'
+            ]
+        ];
+    }
+}

--- a/tests/UnitTests/DogStatsd/TagSerializationTest.php
+++ b/tests/UnitTests/DogStatsd/TagSerializationTest.php
@@ -46,6 +46,14 @@ class TagSerializationTest extends TestCase
             'one string one int' => [
                 ['foo' => 'bar', 'baz' => 42],
                 '|#foo:bar,baz:42'
+            ],
+            'one string one true boolean' => [
+                ['foo' => 'bar', 'baz' => true],
+                '|#foo:bar,baz:true'
+            ],
+            'one string one false boolean' => [
+                ['foo' => 'bar', 'baz' => false],
+                '|#foo:bar,baz:false'
             ]
         ];
     }

--- a/tests/UnitTests/DogStatsd/TagSerializationTest.php
+++ b/tests/UnitTests/DogStatsd/TagSerializationTest.php
@@ -55,6 +55,10 @@ class TagSerializationTest extends TestCase
             'one string one false boolean' => [
                 ['foo' => 'bar', 'baz' => false],
                 '|#foo:bar,baz:false'
+            ],
+            'grab bag' => [
+                ['foo' => 'bar', 'baz' => false, 'nullValue' => null, 'blam' => 1, 'blah' => 0],
+                '|#foo:bar,baz:false,nullValue,blam:1,blah:0'
             ]
         ];
     }

--- a/tests/UnitTests/DogStatsd/TagSerializationTest.php
+++ b/tests/UnitTests/DogStatsd/TagSerializationTest.php
@@ -47,6 +47,7 @@ class TagSerializationTest extends TestCase
                 ['foo' => 'bar', 'baz' => 42],
                 '|#foo:bar,baz:42'
             ],
+            // https://github.com/DataDog/php-datadogstatsd/issues/118
             'one string one true boolean' => [
                 ['foo' => 'bar', 'baz' => true],
                 '|#foo:bar,baz:true'


### PR DESCRIPTION
Fixes https://github.com/DataDog/php-datadogstatsd/issues/118.

Since PHP coerces `true` to `1` and `false` to `''` (empty string) when concatenating, we must explicitly handle booleans when serializing.  I have chosen to serialize to the string literals `'true'` and `'false'` here, which is a bit arbitrary.  Another option is to serialize to `1` and `0`.  Either option is valid.