### PR TITLE
Fix regression preventing string values in set()

### DIFF
--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -238,14 +238,17 @@ class DogStatsd
      * Set
      *
      * @param  string       $stat       The metric
-     * @param  float        $value      The value
+     * @param  string|float $value      The value
      * @param  float        $sampleRate the rate (0-1) for sampling.
      * @param  array|string $tags       Key Value array of Tag => Value, or single tag as string
      * @return void
      **/
     public function set($stat, $value, $sampleRate = 1.0, $tags = null)
     {
-        $value = $this->normalizeStat($value);
+        if (!is_string($value)) {
+            $value = $this->normalizeStat($value);
+        }
+
         $this->send(array($stat => "$value|s"), $sampleRate, $tags);
     }
 

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -318,14 +318,16 @@ class SocketsTest extends SocketSpyTestCase
         );
     }
 
-    public function testSet()
+    /**
+     * @dataProvider setProvider
+     * @param $stat
+     * @param $value
+     * @param $sampleRate
+     * @param $tags
+     * @param $expectedUdpMessage
+     */
+    public function testSet($stat, $value, $sampleRate, $tags, $expectedUdpMessage)
     {
-        $stat = 'some.set_metric';
-        $value = 22239;
-        $sampleRate = 1.0;
-        $tags = array('little' => 'bit');
-        $expectedUdpMessage = 'some.set_metric:22239|s|#little:bit';
-
         $dog = new DogStatsd(array("disable_telemetry" => false));
 
         $dog->set(
@@ -348,6 +350,33 @@ class SocketsTest extends SocketSpyTestCase
         $this->assertSameWithTelemetry(
             $expectedUdpMessage,
             $argsPassedToSocketSendTo[1]
+        );
+    }
+
+    public function setProvider()
+    {
+        return array(
+            'integer' => array(
+                'some.int_metric',
+                1,
+                1.0,
+                array('little' => 'bit'),
+                'some.int_metric:1|s|#little:bit'
+            ),
+            'float' => array(
+                'some.float_metric',
+                3.1415926535898,
+                1.0,
+                array('little' => 'bit'),
+                'some.float_metric:3.14|s|#little:bit'
+            ),
+            'string' => array(
+                'some.string_metric',
+                'uniqueval',
+                1.0,
+                array('little' => 'bit'),
+                'some.string_metric:uniqueval|s|#little:bit'
+            ),
         );
     }
 


### PR DESCRIPTION
Fixes the regression and adjusts the typehint to show that strings are allowed

Closes #120