### PR TITLE
[maintenance] - Add gitattributes file to ignore export of non-source files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+/.circleci            export-ignore
+/.github              export-ignore
+/examples             export-ignore
+/tests                export-ignore
+.gitignore            export-ignore
+.phpcs.xml            export-ignore
+CHANGELOG.md          export-ignore
+LICENSE-3rdparty.csv  export-ignore
+README.md             export-ignore
+phpunit.xml           export-ignore


### PR DESCRIPTION
Hi! I propose a small addition that will eliminate listed files when installing the library. They are not useful for end-user :)