### PR TITLE
Add getter for `BatchedDogStatsd::$bufferLength`

### DIFF
--- a/src/BatchedDogStatsd.php
+++ b/src/BatchedDogStatsd.php
@@ -55,4 +55,12 @@ class BatchedDogStatsd extends DogStatsd
         static::$buffer = array();
         static::$bufferLength = 0;
     }
+
+    /**
+     * @return int
+     */
+    public static function getBufferLength()
+    {
+        return self::$bufferLength;
+    }
 }

--- a/tests/UnitTests/BatchedDogStatsdTest.php
+++ b/tests/UnitTests/BatchedDogStatsdTest.php
@@ -74,4 +74,26 @@ class BatchedDogStatsdTest extends SocketSpyTestCase
             array("metrics" => 3)
         );
     }
+
+    public function testGetBufferLength() {
+        $batchedDog = new BatchedDogStatsd();
+
+        $this->assertEquals(0, BatchedDogStatsd::getBufferLength());
+
+        $batchedDog->gauge("some-value", 1);
+
+        $this->assertEquals(1, BatchedDogStatsd::getBufferLength());
+    }
+
+    public function testGetBufferLengthAfterExceedingMaxBufferLength()
+    {
+        BatchedDogStatsd::$maxBufferLength = 2;
+
+        $batchedDog = new BatchedDogStatsd();
+
+        $batchedDog->increment(["first-value", "another-value", "yet-another-value"]);
+        $batchedDog->gauge("some-value", 1);
+
+        $this->assertEquals(1, BatchedDogStatsd::getBufferLength());
+    }
 }


### PR DESCRIPTION
In an application, before shutdown I would like to be able to push any outstanding items in the buffer. If the buffer is empty, we do not need to make an unnecessary request to DD.