### PR TITLE
chore: add phpdocs for constructor config

### DIFF
--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -70,9 +70,19 @@ class DogStatsd
      * datadog_host,
      * global_tags,
      * decimal_precision,
-     * metric_prefix
+     * metric_prefix,
+     * disable_telemetry
      *
-     * @param array $config
+     * @param array{
+     *     host: string,
+     *     port: int,
+     *     socket_path: string,
+     *     datadog_host: string,
+     *     global_tags: string[],
+     *     decimal_precision: int,
+     *     metric_prefix: string,
+     *     disable_telemetry: bool
+     * } $config
      */
     public function __construct(array $config = array())
     {


### PR DESCRIPTION
Small improvement that will enable phpstorm and other support which is typing out the array parameters aka. keys with its expected type value. Also the disable_telemetry parameter was missing. I don't find constructor values listed honestly, but kept it just for the BC