### PR TITLE
Add tag cardinality common field

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ After the client is created, you can start sending Service Checks to Datadog. Se
 
 ### Origin detection in Kubernetes
 
-Origin detection is a method to detect which pod DogStatsD packets are coming from in order to add the pod's tags to the tag list.
+Origin detection is a method to detect the pod that DogStatsD packets are coming from and add the pod's tags to the tag list.
 
 #### Tag cardinality
 

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -472,10 +472,11 @@ class DogStatsd
     }
 
     /**
-     * validateCardinality ensures the given cardinality is valid
-     * either null, "none", "low", "orchestrator" or "high".
-     * Return the lower case cardinality if it is valid,
-     * null if it is not.
+     * validateCardinality ensures the given cardinality is valid either null,
+     * "none", "low", "orchestrator" or "high".
+     * Return the lower case cardinality if it is valid.
+     * If it is not valid, raises a warning and if the warning is handled
+     * returns null if it is not valid.
      *
      * @param string $cardinality the cardinality
      */

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -130,7 +130,7 @@ class DogStatsd
             ? getenv('DD_CARDINALITY') : ((getenv('DATADOG_CARDINALITY'))
             ? getenv('DATADOG_CARDINALITY') : null));
 
-    $this->datadogHost = isset($config['datadog_host']) ? $config['datadog_host'] : 'https://app.datadoghq.com';
+        $this->datadogHost = isset($config['datadog_host']) ? $config['datadog_host'] : 'https://app.datadoghq.com';
 
         $this->decimalPrecision = isset($config['decimal_precision']) ? $config['decimal_precision'] : 2;
 
@@ -489,8 +489,10 @@ class DogStatsd
         if (in_array($cardinality, ["none", "low", "orchestrator", "high"])) {
             return $cardinality;
         } else {
-            trigger_error("Cardinality must be one of the following: 'none', 'low', 'orchestrator' or 'high'.",
-                          E_USER_WARNING);
+            trigger_error(
+                "Cardinality must be one of the following: 'none', 'low', 'orchestrator' or 'high'.",
+                E_USER_WARNING
+            );
             return null;
         }
     }


### PR DESCRIPTION
This adds the tag cardinality field.

The cardinality field is added to the metric as a `card:` field. 

The field can be set globally

- passing the field as an option.

```php
    $dog = new DogStatsd(array(
            "cardinality" => "orchestrator"
        ));
```

- setting the value to either `DD_CARDINALITY` or `DATADOG_CARDINALITY`.

Or per metric by:

- passing a cardinality parameter when creating a metric.

```php
        $dog->gauge('metric', 42, 1.0, null, "high");
```

Can be one of "none", "low", "orchestrator", "high". Passing an invalid value will result in a warning being raised. If the warning is ignored, the field is not added. See [here](https://docs.datadoghq.com/containers/kubernetes/tag/?tab=datadogoperator) for details on these options.