### PR TITLE
Run tests on PHP 8.4 as well in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.2', '8.3']
+        php-versions: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.2', '8.3', '8.4']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Include PHP 8.4 among the PHP versions for the CI checks, to ensure compatibility with PHP 8.4.