### PR TITLE
Let user determine how to handle socket errors

### DIFF
--- a/tests/TestHelpers/SocketSpy.php
+++ b/tests/TestHelpers/SocketSpy.php
@@ -43,6 +43,11 @@ class SocketSpy
     public $returnErrorOnSend = false;
 
     /**
+     * @var null|callable
+     */
+    public $errorThrownOnSend = null;
+
+    /**
      * @param int $domain
      * @param int $type
      * @param int $protocol
@@ -88,6 +93,10 @@ class SocketSpy
         $addr,
         $port
     ) {
+        if ($this->errorThrownOnSend !== null) {
+            call_user_func($this->errorThrownOnSend, $socket, $buf, $len, $flags);
+        }
+
         if ($this->returnErrorOnSend === true) {
           return false;
         }

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -351,7 +351,7 @@ class SocketsTest extends SocketSpyTestCase
     public function testGauge()
     {
         $this->disableOriginDetectionLinux();
-        
+
         $stat = 'some.gauge_metric';
         $value = 5;
         $sampleRate = 1.0;
@@ -1512,7 +1512,10 @@ class SocketsTest extends SocketSpyTestCase
         }));
 
         $this->getSocketSpy()->errorThrownOnSend = function () {
-            throw new ErrorException('ErrorException: socket_sendto(): Unable to write to socket [111]: Connection refused');
+            trigger_error(
+                'ErrorException: socket_sendto(): Unable to write to socket [111]: Connection refused',
+                E_USER_WARNING
+            );
         };
         $dog->increment('test');
         $this->assertNotNull($errorStore);

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -1507,7 +1507,7 @@ class SocketsTest extends SocketSpyTestCase
         $this->disableOriginDetectionLinux();
 
         $errorStore = null;
-        $dog = new DogStatsd(array("disable_telemetry" => false, "socket_failure_handler" => function ($err) use (&$errorStore) {
+        $dog = new DogStatsd(array("disable_telemetry" => false, "flush_failure_handler" => function ($err) use (&$errorStore) {
             $errorStore = $err;
         }));
 


### PR DESCRIPTION
This creates a new parameter for configuration: `flush_failure_handler`. This is a callable or null.

Why this is necessary: we see socket failures happen far too frequently, and it's very annoying to have to wrap each and every stat write in a try-catch. In our code, we can simply pass something like:

```php
$statsClient = new DogStatsd([
  'flush_failure_handler' => static fn (Throwable $e) => Log::warning("Failure to flush metrics.", ['e' => $e])
]);
```

which will write an error to our logs and carry on.

See https://github.com/DataDog/php-datadogstatsd/issues/168