### PR TITLE
Add filter_global_tags_callback to DogStatsd config

### DIFF
--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -151,7 +151,7 @@ class DogStatsd
 
         $this->decimalPrecision = isset($config['decimal_precision']) ? $config['decimal_precision'] : 2;
 
-        $this->globalTags = isset($config['global_tags']) ? $config['global_tags'] : array();
+        $this->globalTags = $this->normalizeTags(isset($config['global_tags']) ? $config['global_tags'] : array());
         if (getenv('DD_ENTITY_ID')) {
             $this->globalTags['dd.internal.entity_id'] = getenv('DD_ENTITY_ID');
         }

--- a/src/DogStatsd.php
+++ b/src/DogStatsd.php
@@ -90,8 +90,9 @@ class DogStatsd
      * metric_prefix,
      * disable_telemetry,
      * container_id,
-     * origin_detection
-     * flush_failure_handler
+     * origin_detection,
+     * flush_failure_handler,
+     * filter_global_tags_callback
      *
      * @param array{
      *     host?: string,
@@ -105,7 +106,8 @@ class DogStatsd
      *     disable_telemetry?: bool,
      *     container_id?: string,
      *     origin_detection?: bool,
-     *     flush_failure_handler?: callable
+     *     flush_failure_handler?: callable,
+     *     filter_global_tags_callback?: (callable(array<array-key, mixed>): array<array-key, mixed>),
      * } $config
      */
     public function __construct(array $config = array())
@@ -161,6 +163,9 @@ class DogStatsd
         }
         if (getenv('DD_VERSION')) {
             $this->globalTags['version'] = getenv('DD_VERSION');
+        }
+        if (isset($config['filter_global_tags_callback'])) {
+            $this->globalTags = call_user_func($config['filter_global_tags_callback'], $this->globalTags);
         }
 
         $this->metricPrefix = isset($config['metric_prefix']) ? "$config[metric_prefix]." : '';

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -1834,6 +1834,49 @@ class SocketsTest extends SocketSpyTestCase
         );
     }
 
+    public function testFilterGlobalTagsCallbackReceivesNormalizedStringTags()
+    {
+        $this->disableOriginDetectionLinux();
+
+        $receivedTags = null;
+        $dog = new DogStatsd(array(
+            'global_tags' => 'env:prod,service:web,version',
+            'disable_telemetry' => false,
+            'filter_global_tags_callback' => function (array $tags) use (&$receivedTags) {
+                $receivedTags = $tags;
+                $tags['service'] = 'filteredService';
+
+                return $tags;
+            }
+        ));
+
+        $this->assertSame(
+            array(
+                'env' => 'prod',
+                'service' => 'web',
+                'version' => null
+            ),
+            $receivedTags
+        );
+
+        $dog->timing('metric', 42, 1.0);
+        $spy = $this->getSocketSpy();
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+        $expectedUdpMessage = 'metric:42|ms|#env:prod,service:filteredService,version';
+        $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSameWithTelemetry(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendTo[1],
+            "",
+            array("tags" => "env:prod,service:filteredService,version")
+        );
+    }
+
     public function testCardinality()
     {
         $dog = new DogStatsd(array("disable_telemetry" => false));

--- a/tests/UnitTests/DogStatsd/SocketsTest.php
+++ b/tests/UnitTests/DogStatsd/SocketsTest.php
@@ -1750,6 +1750,90 @@ class SocketsTest extends SocketSpyTestCase
         );
     }
 
+    public function testFilterGlobalTagsCallbackReceivesConfigAndEnvTags()
+    {
+        putenv("DD_VERSION=1.2.3");
+        putenv("DD_ENV=prod");
+        putenv("DD_SERVICE=myService");
+        $this->disableOriginDetectionLinux();
+
+        $receivedTags = null;
+        $dog = new DogStatsd(array(
+            'global_tags' => array(
+                'my_tag' => 'tag_value',
+            ),
+            'disable_telemetry' => false,
+            'filter_global_tags_callback' => function ($tags) use (&$receivedTags) {
+                $receivedTags = $tags;
+                unset($tags['env']);
+                $tags['service'] = 'filteredService';
+                $tags['callback_tag'] = 'callback_value';
+
+                return $tags;
+            }
+        ));
+
+        $this->assertSame(
+            array(
+                'my_tag' => 'tag_value',
+                'env' => 'prod',
+                'service' => 'myService',
+                'version' => '1.2.3'
+            ),
+            $receivedTags
+        );
+
+        $dog->timing('metric', 42, 1.0);
+        $spy = $this->getSocketSpy();
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+        $expectedUdpMessage = 'metric:42|ms|#my_tag:tag_value,service:filteredService,version:1.2.3,callback_tag:callback_value';
+        $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSameWithTelemetry(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendTo[1],
+            "",
+            array("tags" => "my_tag:tag_value,service:filteredService,version:1.2.3,callback_tag:callback_value")
+        );
+    }
+
+    public function testFilterGlobalTagsCallbackCanRemoveAllTags()
+    {
+        putenv("DD_VERSION=1.2.3");
+        putenv("DD_ENV=prod");
+        putenv("DD_SERVICE=myService");
+        $this->disableOriginDetectionLinux();
+
+        $dog = new DogStatsd(array(
+            'global_tags' => array(
+                'my_tag' => 'tag_value',
+            ),
+            'disable_telemetry' => false,
+            'filter_global_tags_callback' => function ($tags) {
+                return array();
+            }
+        ));
+
+        $dog->timing('metric', 42, 1.0);
+        $spy = $this->getSocketSpy();
+        $this->assertSame(
+            1,
+            count($spy->argsFromSocketSendtoCalls),
+            'Should send 1 UDP message'
+        );
+        $expectedUdpMessage = 'metric:42|ms';
+        $argsPassedToSocketSendTo = $spy->argsFromSocketSendtoCalls[0];
+
+        $this->assertSameWithTelemetry(
+            $expectedUdpMessage,
+            $argsPassedToSocketSendTo[1]
+        );
+    }
+
     public function testCardinality()
     {
         $dog = new DogStatsd(array("disable_telemetry" => false));


### PR DESCRIPTION
Due to how the logic is setup, globalTags can be set, but always have a handful of DD specific tags added to them.

To reduce metric cardinality, we would like to just keep version and service.

I would say just not set DD tags if global_tags was passed in this, but this might be a BC